### PR TITLE
feat: Introduce image metadata for Power and s390x runners

### DIFF
--- a/images/centos/scripts/build/configure-image-data.sh
+++ b/images/centos/scripts/build/configure-image-data.sh
@@ -17,20 +17,28 @@ os_version=$(rpm -E %{rhel}) # Get CentOS version
 image_label="centos-${os_version}" # Set image label
 
 # Construct documentation and release URLs
-github_url="https://github.com/actions/runner-images/blob"
-software_url="${github_url}/centos${os_version}/${image_version_major}.${image_version_minor}/images/centos/CentOS${os_version}-Readme.md"
+github_url="https://github.com/IBM/action-runner-image-pz/blob/main/images"
+software_url="${github_url}/centos/toolsets/toolset-${image_version_major}${image_version_minor}.json"
 releaseUrl="https://github.com/actions/runner-images/releases/tag/centos${os_version}%2F${image_version_major}.${image_version_minor}"
+
+runner_image_version="$(date  +%Y%m%d)"
+image_build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+image_builder_id=$(cat /etc/machine-id 2>/dev/null || hostname -s 2>/dev/null)
 
 # Create the image data JSON file
 cat <<EOF > "$imagedata_file"
 [
+  {
+    "group": "Runner Image Provisioner",
+    "detail": "Commit: ${BUILD_SHA}\nBuild Date: ${image_build_date}\nBuilder ID: ${image_builder_id}"
+  },
   {
     "group": "Operating System",
     "detail": "${os_name}"
   },
   {
     "group": "Runner Image",
-    "detail": "Image: ${image_label}\nVersion: ${image_version}\nIncluded Software: ${software_url}\nImage Release: ${releaseUrl}"
+    "detail": "Image: ${image_label}\nVersion: ${runner_image_version}\nIncluded Software: ${software_url}\nImage Release: ${releaseUrl}"
   }
 ]
 EOF

--- a/images/ubuntu/scripts/build/configure-image-data.sh
+++ b/images/ubuntu/scripts/build/configure-image-data.sh
@@ -14,20 +14,30 @@ os_version=$(lsb_release -rs)
 image_label="ubuntu-${os_version}"
 version_major=${os_version/.*/}
 version_wo_dot=${os_version/./}
-github_url="https://github.com/actions/runner-images/blob"
 
-software_url="${github_url}/ubuntu${version_major}/${image_version_major}.${image_version_minor}/images/ubuntu/Ubuntu${version_wo_dot}-Readme.md"
-releaseUrl="https://github.com/actions/runner-images/releases/tag/ubuntu${version_major}%2F${image_version_major}.${image_version_minor}"
+github_url="https://github.com/IBM/action-runner-image-pz/blob/main/images"
+software_url="${github_url}/ubuntu/toolsets/toolset-${image_version_major}${image_version_minor}.json"
+releaseUrl="https://github.com/IBM/action-runner-image-pz/releases/tag/ubuntu${version_major}%2F${image_version_major}.${image_version_minor}"
+
+## Following are custom values for P/Z self-hosted runners
+## todo: extend this with CI build number
+runner_image_version="$(date  +%Y%m%d)"
+image_build_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+image_builder_id=$(cat /etc/machine-id 2>/dev/null || hostname -s 2>/dev/null)
 
 cat <<EOF > "$imagedata_file"
 [
+  {
+    "group": "Runner Image Provisioner",
+    "detail": "Commit: ${BUILD_SHA}\nBuild Date: ${image_build_date}\nBuilder ID: ${image_builder_id}"
+  },
   {
     "group": "Operating System",
     "detail": "${os_name}"
   },
   {
     "group": "Runner Image",
-    "detail": "Image: ${image_label}\nVersion: ${image_version}\nIncluded Software: ${software_url}\nImage Release: ${releaseUrl}"
+    "detail": "Image: ${image_label}\nVersion: ${runner_image_version}\nIncluded Software: ${software_url}\nImage Release: ${releaseUrl}"
   }
 ]
 EOF

--- a/scripts/helpers/setup_install.sh
+++ b/scripts/helpers/setup_install.sh
@@ -11,9 +11,6 @@ source "${CURRENT_DIR}"/run_script.sh
 # Configure limits
 run_script "${INSTALLER_SCRIPT_FOLDER}/configure-limits.sh" 
 
-# Configure image data
-run_script "${INSTALLER_SCRIPT_FOLDER}/configure-image-data.sh" "IMAGE_VERSION" "IMAGEDATA_FILE"
-
 # Configure environment
 run_script "${INSTALLER_SCRIPT_FOLDER}/configure-environment.sh" "IMAGE_OS" "IMAGE_VERSION" "HELPER_SCRIPTS"
 
@@ -206,6 +203,9 @@ run_script "${INSTALLER_SCRIPT_FOLDER}/install-docker.sh" "DOCKERHUB_PULL_IMAGES
 run_script "${INSTALLER_SCRIPT_FOLDER}/install-pipx-packages.sh" "HELPER_SCRIPTS" "INSTALLER_SCRIPT_FOLDER" "ARCH"
 
 run_script "${INSTALLER_SCRIPT_FOLDER}/install-homebrew.sh" "DEBIAN_FRONTEND" "HELPER_SCRIPTS" "INSTALLER_SCRIPT_FOLDER" "ARCH"
+
+# Configure image data
+run_script "${INSTALLER_SCRIPT_FOLDER}/configure-image-data.sh" "IMAGE_VERSION" "IMAGEDATA_FILE"
 
 # echo 'Rebooting VM...'
 # sudo reboot

--- a/scripts/helpers/setup_vars.sh
+++ b/scripts/helpers/setup_vars.sh
@@ -121,7 +121,7 @@ toolset_file_name="toolset-$(echo "$IMAGE_VERSION" | sed 's/\.//g').json"
 image_folder="/var/tmp/imagegeneration-${IMAGE_OS}-${IMAGE_VERSION}"
 helper_script_folder="${image_folder}/helpers"
 installer_script_folder="${image_folder}/installers"
-imagedata_file="${image_folder}/imagedata.json"
+imagedata_file="/opt/runner-cache/.setup_info"
 
 # Export variables for use in other scripts
 # shellcheck disable=SC2034

--- a/scripts/lxd.sh
+++ b/scripts/lxd.sh
@@ -275,7 +275,7 @@ prolog() {
   HOST_INSTALLER_SCRIPT_FOLDER="${HELPERS_DIR}/../../images/${HOST_OS_NAME}/scripts/build"
   BUILD_HOME="/home"
   BUILD_SHA=$(git rev-parse HEAD)
-  BUILD_DATE=$(date -u)
+  BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
   LXD_CONTAINER="${IMAGE_OS}:${IMAGE_VERSION}"
 
   mkdir -p ${EXPORT}


### PR DESCRIPTION
## Description

GitHub-hosted runners display rich image metadata (such as **Runner Image**, **Operating System**, and **Runner Image Provisioner**) in the `Set up job` header of every workflow. This information is injected during image provisioning by GitHub-internal builders and is not available by default for self-hosted runners.

To bridge this gap, this change enables self-hosted runners to surface similar image metadata by consuming a `.setup_info` file populated during image build time. When present, the runner can read this file and display the metadata in the `Set up job` header, providing better visibility into the exact image used for a workflow run.

This improves debuggability for administrators, helps identify image-specific failures, and allows the community to stay aligned with the latest image updates.


## Changes Implemented

- Updated the image build flow so that `configure-image-data.sh` is executed **after** the runner packages are installed.
  - This ensures that all required dependencies created by `runner-packages` exist before image metadata is generated.
- Updated the `imagedata_file` path to point to the runner’s root directory, which is where the runner expects the `.setup_info` file to be present.
- Added support for populating `.setup_info` with image metadata that can be surfaced by the self-hosted runner during job setup.

NOTE: The current `softwareURL` and `releaseURL` are placeholders until we have something more concrete in the form of README.md to indicate the SBOMs of our images. 

## Future Work

- Introduce a dedicated README (similar to GitHub-hosted runner image READMEs) that documents:
  - Installed packages
  - Toolchains
  - Image-specific configuration
 
This will improve transparency, help users validate installed tooling, and align documentation with the image build process.
