### PR TITLE
Update toolsets: add latest runtimes, remove EOL versions, and apply stability fixes

### DIFF
--- a/images/centos/toolsets/toolset-10.json
+++ b/images/centos/toolsets/toolset-10.json
@@ -11,7 +11,8 @@
                 "3.10.*",
                 "3.11.*",
                 "3.12.*",
-                "3.13.*"
+                "3.13.*",
+                "3.14.*"
             ]
         },
         {
@@ -30,9 +31,9 @@
             "platform" : "linux",
             "arch": "x64",
             "versions": [
-                "18.*",
                 "20.*",
-                "22.*"
+                "22.*",
+                "24.*"
             ]
         },
         {
@@ -43,7 +44,8 @@
             "versions": [
                 "1.22.*",
                 "1.23.*",
-                "1.24.*"
+                "1.24.*",
+                "1.25.*"
             ],
             "default": "1.24.*"
         },
@@ -69,7 +71,7 @@
     "java": {
         "default": "17",
         "versions": [ "11", "17", "21", "25"],
-        "maven": "3.9.11"
+        "maven": "3.9.12"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-11076708_latest.zip",
@@ -83,12 +85,13 @@
         "addon_list": [
         ],
         "additional_tools": [
-            "cmake;3.31.5"
+            "cmake;3.31.5",
+            "cmake;4.1.2"
         ],
         "ndk": {
             "default": "27",
             "versions": [
-                "26", "27", "28"
+                "26", "27", "28", "29"
             ]
         }
     },
@@ -172,7 +175,7 @@
         "components": [
             {
                 "package": "containerd.io",
-                "version": "latest"
+                "version": "1.7.27-1"
             },
             {
                 "package": "docker-ce-cli",
@@ -195,7 +198,7 @@
             },
             {
                 "plugin": "compose",
-                "version": "2.29.0",
+                "version": "2.38.2",
                 "asset_map": {
                     "x86_64": "linux-x86_64",
                     "ppc64le": "linux-ppc64le",
@@ -217,7 +220,8 @@
     "dotnet": {
         "versions": [
             "8.0",
-            "9.0"
+            "9.0",
+            "10.0"
         ],
         "tools": [
             { "name": "nbgv", "test": "nbgv --version", "getversion" : "nbgv --version" }

--- a/images/centos/toolsets/toolset-9.json
+++ b/images/centos/toolsets/toolset-9.json
@@ -11,7 +11,8 @@
                 "3.10.*",
                 "3.11.*",
                 "3.12.*",
-                "3.13.*"
+                "3.13.*",
+                "3.14.*"
             ]
         },
         {
@@ -30,9 +31,9 @@
             "platform" : "linux",
             "arch": "x64",
             "versions": [
-                "18.*",
                 "20.*",
-                "22.*"
+                "22.*",
+                "24.*"
             ]
         },
         {
@@ -43,7 +44,8 @@
             "versions": [
                 "1.22.*",
                 "1.23.*",
-                "1.24.*"
+                "1.24.*",
+                "1.25.*"
             ],
             "default": "1.24.*"
         },
@@ -69,7 +71,7 @@
     "java": {
         "default": "17",
         "versions": [ "11", "17", "21", "25"],
-        "maven": "3.9.11"
+        "maven": "3.9.12"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-11076708_latest.zip",
@@ -83,12 +85,13 @@
         "addon_list": [
         ],
         "additional_tools": [
-            "cmake;3.31.5"
+            "cmake;3.31.5",
+            "cmake;4.1.2"
         ],
         "ndk": {
             "default": "27",
             "versions": [
-                "26", "27", "28"
+                "26", "27", "28", "29"
             ]
         }
     },
@@ -172,7 +175,7 @@
         "components": [
             {
                 "package": "containerd.io",
-                "version": "latest"
+                "version": "1.7.27-1"
             },
             {
                 "package": "docker-ce-cli",
@@ -195,7 +198,7 @@
             },
             {
                 "plugin": "compose",
-                "version": "2.29.0",
+                "version": "2.38.2",
                 "asset_map": {
                     "x86_64": "linux-x86_64",
                     "ppc64le": "linux-ppc64le",
@@ -217,7 +220,8 @@
     "dotnet": {
         "versions": [
             "8.0",
-            "9.0"
+            "9.0",
+            "10.0"
         ],
         "tools": [
             { "name": "nbgv", "test": "nbgv --version", "getversion" : "nbgv --version" }

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -11,7 +11,8 @@
                 "3.10.*",
                 "3.11.*",
                 "3.12.*",
-                "3.13.*"
+                "3.13.*",
+                "3.14.*"
             ]
         },
         {
@@ -32,7 +33,6 @@
             "platform" : "linux",
             "arch": "x64",
             "versions": [
-                "18.*",
                 "20.*",
                 "22.*",
                 "24.*"
@@ -56,7 +56,6 @@
             "platform_version": "22.04",
             "arch": "x64",
             "versions": [
-                "3.1.*",
                 "3.2.*",
                 "3.3.*",
                 "3.4.*"
@@ -73,8 +72,8 @@
     ],
     "java": {
         "default": "11",
-        "versions": [ "11", "17", "21", "25"],
-        "maven": "3.9.11"
+        "versions": ["11", "17", "21", "25"],
+        "maven": "3.9.12"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-9477386_latest.zip",
@@ -281,7 +280,8 @@
     "dotnet": {
         "versions": [
             "8.0",
-            "9.0"
+            "9.0",
+            "10.0"
         ],
         "tools": [
             { "name": "nbgv", "test": "nbgv --version", "getversion" : "nbgv --version" }
@@ -297,7 +297,6 @@
     },
     "gcc": {
         "versions": [
-            "g++-9",
             "g++-10",
             "g++-12"
         ]

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -11,7 +11,8 @@
                 "3.10.*",
                 "3.11.*",
                 "3.12.*",
-                "3.13.*"
+                "3.13.*",
+                "3.14.*"
             ]
         },
         {
@@ -30,9 +31,9 @@
             "platform" : "linux",
             "arch": "x64",
             "versions": [
-                "18.*",
                 "20.*",
-                "22.*"
+                "22.*",
+                "24.*"
             ]
         },
         {
@@ -43,7 +44,8 @@
             "versions": [
                 "1.22.*",
                 "1.23.*",
-                "1.24.*"
+                "1.24.*",
+                "1.25.*"
             ],
             "default": "1.24.*"
         },
@@ -69,7 +71,7 @@
     "java": {
         "default": "17",
         "versions": [ "11", "17", "21", "25"],
-        "maven": "3.9.11"
+        "maven": "3.9.12"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-11076708_latest.zip",
@@ -83,12 +85,13 @@
         "addon_list": [
         ],
         "additional_tools": [
-            "cmake;3.31.5"
+            "cmake;3.31.5",
+            "cmake;4.1.2"
         ],
         "ndk": {
             "default": "27",
             "versions": [
-                "26", "27", "28"
+                "26", "27", "28", "29"
             ]
         }
     },
@@ -155,6 +158,7 @@
             "binutils",
             "bison",
             "brotli",
+            "libnss3-tools",
             "coreutils",
             "file",
             "findutils",
@@ -216,7 +220,7 @@
             },
             {
                 "plugin": "compose",
-                "version": "2.29.0",
+                "version": "2.38.2",
                 "asset_map": {
                     "x86_64": "linux-x86_64",
                     "ppc64le": "linux-ppc64le",
@@ -238,7 +242,8 @@
     "dotnet": {
         "versions": [
             "8.0",
-            "9.0"
+            "9.0",
+            "10.0"
         ],
         "tools": [
             { "name": "nbgv", "test": "nbgv --version", "getversion" : "nbgv --version" }


### PR DESCRIPTION
### **Description**

Updated runner toolsets to keep environments current with upstream releases and security patches. Added new language runtimes, removed deprecated ones, and applied fixes for stability on CentOS and Ubuntu.

**Changes:**

- **Runtimes:**  Added Python 3.14, Go 1.25, Node.js 24, .NET 10
- **Android:**  Added NDK 29 and CMake 4.1.2
- **Dependencies:**  Updated Maven to 3.9.12 and Docker Compose to 2.38.2
- **Removals:**  Dropped Node.js 18; on Ubuntu 22.04 removed Ruby 3.1 and GCC 9
- **Fixes:**

  - CentOS: pinned `containerd.io` to 1.7.27-1 to avoid instability from `latest`
  - Ubuntu 24.04: added `libnss3-tools` for certificate utilities

**Why:**

- Keeps images aligned with latest upstream versions
- Removes EOL components to reduce CVEs and maintenance overhead
- Stability improvements for container runtime and PKI tooling