### PR TITLE
build: optimize docker daemon config and remove explicit MTU

### DIFF
--- a/images/ubuntu/scripts/build/install-docker.sh
+++ b/images/ubuntu/scripts/build/install-docker.sh
@@ -73,37 +73,34 @@ groupmod -g "$gid" docker
 [ ! -d /etc/docker ] && mkdir /etc/docker
 cat << EOF > /etc/docker/daemon.json
 {
-    "mtu": 1460,
-    "default-network-opts": {
-        "bridge": {
-            "com.docker.network.driver.mtu": "1460"
-        }
+  "data-root": "/var/lib/docker",
+  "log-driver": "local",
+  "log-opts": {
+    "max-size": "100m",
+    "max-file": "6",
+    "compress": "true",
+    "mode": "non-blocking",
+    "max-buffer-size": "4m"
+  },
+  "default-ulimits": {
+    "nofile": {
+      "Name": "nofile",
+      "Hard": 65536,
+      "Soft": 65536
     },
-    "data-root": "/var/lib/docker",
-    "log-driver": "json-file",
-    "log-opts": {
-        "max-size": "360m",
-        "max-file": "4"
-    },
-    "default-ulimits": {
-        "nofile": {
-            "Name": "nofile",
-            "Hard": 65536,
-            "Soft": 65536
-        },
-        "nproc": {
-            "Name": "nproc",
-            "Hard": 65536,
-            "Soft": 65536
-        }
-    },
-    "live-restore": true,
-    "max-concurrent-downloads": 10,
-    "max-concurrent-uploads": 10,
-    "storage-driver": "overlay2",
-    "exec-opts": [
-        "native.cgroupdriver=systemd"
-    ]
+    "nproc": {
+      "Name": "nproc",
+      "Hard": 65536,
+      "Soft": 65536
+    }
+  },
+  "live-restore": true,
+  "max-concurrent-downloads": 20,
+  "max-concurrent-uploads": 10,
+  "storage-driver": "overlay2",
+  "exec-opts": [
+    "native.cgroupdriver=systemd"
+  ]
 }
 EOF
 


### PR DESCRIPTION
**Description:** 
This PR updates the `install-docker.sh` scripts for both Ubuntu and CentOS to apply a robust, production-ready `daemon.json`.

**Key Changes:**

1. **Network:**  Removed static `mtu` setting (fixes potential mismatch with host).
2. **Logging:**  Switched to `local` driver with `mode: non-blocking` and compression enabled.
3. **Consistency:**  Applied the same configuration to the CentOS image build.

Fixes:  #7