### PR TITLE
feat: Implement environment-aware LXD preseed configuration

### DIFF
--- a/scripts/assets/lxd_init_container_ppc64le.yml
+++ b/scripts/assets/lxd_init_container_ppc64le.yml
@@ -1,0 +1,30 @@
+config: {}
+cluster: null
+networks:
+- config:
+    bridge.mtu: "1460"
+    ipv4.address: auto
+    ipv6.address: auto
+  description: "gaplib network"
+  name: lxdbr0
+  type: bridge
+  project: default
+storage_pools:
+- config: {}
+  description: "gaplib storage pool"
+  name: default
+  driver: dir
+profiles:
+- config: {}
+  description: "gaplib"
+  devices:
+    eth0:
+      name: eth0
+      nictype: bridged
+      parent: lxdbr0
+      type: nic
+    root:
+      path: /
+      pool: default
+      type: disk
+  name: default

--- a/scripts/assets/lxd_init_container_s390x.yml
+++ b/scripts/assets/lxd_init_container_s390x.yml
@@ -1,0 +1,29 @@
+config: {}
+cluster: null
+networks:
+- config:
+    ipv4.address: auto
+    ipv6.address: auto
+  description: "gaplib network"
+  name: lxdbr0
+  type: bridge
+  project: default
+storage_pools:
+- config: {}
+  description: "gaplib storage pool"
+  name: default
+  driver: dir
+profiles:
+- config: {}
+  description: "gaplib"
+  devices:
+    eth0:
+      name: eth0
+      nictype: bridged
+      parent: lxdbr0
+      type: nic
+    root:
+      path: /
+      pool: default
+      type: disk
+  name: default

--- a/scripts/assets/lxd_init_container_x86_64.yml
+++ b/scripts/assets/lxd_init_container_x86_64.yml
@@ -1,0 +1,29 @@
+config: {}
+cluster: null
+networks:
+- config:
+    ipv4.address: auto
+    ipv6.address: auto
+  description: "gaplib network"
+  name: lxdbr0
+  type: bridge
+  project: default
+storage_pools:
+- config: {}
+  description: "gaplib storage pool"
+  name: default
+  driver: dir
+profiles:
+- config: {}
+  description: "gaplib"
+  devices:
+    eth0:
+      name: eth0
+      nictype: bridged
+      parent: lxdbr0
+      type: nic
+    root:
+      path: /
+      pool: default
+      type: disk
+  name: default

--- a/scripts/assets/lxd_init_host_ppc64le.yml
+++ b/scripts/assets/lxd_init_host_ppc64le.yml
@@ -1,0 +1,49 @@
+config: {}
+networks:
+- config:
+    ipv4.address: auto
+    ipv4.nat: "true"
+    ipv6.address: auto
+    ipv6.nat: "true"
+  description: Default LXD bridge
+  name: lxdbr0
+  type: bridge
+  project: default
+storage_pools:
+- config:
+    lvm.thinpool_name: LXDThinPool
+    lvm.vg_name: default
+    size: 30GiB
+    source: /var/snap/lxd/common/lxd/disks/default.img
+    volume.size: 60GiB
+  description: Default storage pool
+  name: default
+  driver: lvm
+profiles:
+- config:
+    boot.autostart: "true"
+    linux.kernel_modules: ip_vs,ip_vs_rr,ip_vs_wrr,ip_vs_sh,ip_tables,ip6_tables,netlink_diag,nf_nat,overlay,br_netfilter
+    raw.lxc: |
+      lxc.mount.auto=proc:rw sys:rw cgroup:rw
+      lxc.cgroup.devices.allow=a
+      lxc.cap.drop=
+    security.nesting: "true"
+  description: Default LXD profile
+  devices:
+    eth0:
+      name: eth0
+      network: lxdbr0
+      type: nic
+    root:
+      path: /
+      pool: default
+      type: disk
+  name: default
+projects:
+- config:
+    features.images: "true"
+    features.networks: "true"
+    features.profiles: "true"
+    features.storage.volumes: "true"
+  description: Default LXD project
+  name: default

--- a/scripts/assets/lxd_init_host_s390x.yml
+++ b/scripts/assets/lxd_init_host_s390x.yml
@@ -1,0 +1,49 @@
+config: {}
+networks:
+- config:
+    ipv4.address: auto
+    ipv4.nat: "true"
+    ipv6.address: auto
+    ipv6.nat: "true"
+  description: Default LXD bridge
+  name: lxdbr0
+  type: bridge
+  project: default
+storage_pools:
+- config:
+    lvm.thinpool_name: LXDThinPool
+    lvm.vg_name: default
+    size: 30GiB
+    source: /var/snap/lxd/common/lxd/disks/default.img
+    volume.size: 60GiB
+  description: Default storage pool
+  name: default
+  driver: lvm
+profiles:
+- config:
+    boot.autostart: "true"
+    linux.kernel_modules: ip_vs,ip_vs_rr,ip_vs_wrr,ip_vs_sh,ip_tables,ip6_tables,netlink_diag,nf_nat,overlay,br_netfilter
+    raw.lxc: |
+      lxc.mount.auto=proc:rw sys:rw cgroup:rw
+      lxc.cgroup.devices.allow=a
+      lxc.cap.drop=
+    security.nesting: "true"
+  description: Default LXD profile
+  devices:
+    eth0:
+      name: eth0
+      network: lxdbr0
+      type: nic
+    root:
+      path: /
+      pool: default
+      type: disk
+  name: default
+projects:
+- config:
+    features.images: "true"
+    features.networks: "true"
+    features.profiles: "true"
+    features.storage.volumes: "true"
+  description: Default LXD project
+  name: default

--- a/scripts/assets/lxd_init_host_x86_64.yml
+++ b/scripts/assets/lxd_init_host_x86_64.yml
@@ -1,0 +1,49 @@
+config: {}
+networks:
+- config:
+    ipv4.address: auto
+    ipv4.nat: "true"
+    ipv6.address: auto
+    ipv6.nat: "true"
+  description: Default LXD bridge
+  name: lxdbr0
+  type: bridge
+  project: default
+storage_pools:
+- config:
+    lvm.thinpool_name: LXDThinPool
+    lvm.vg_name: default
+    size: 30GiB
+    source: /var/snap/lxd/common/lxd/disks/default.img
+    volume.size: 60GiB
+  description: Default storage pool
+  name: default
+  driver: lvm
+profiles:
+- config:
+    boot.autostart: "true"
+    linux.kernel_modules: ip_vs,ip_vs_rr,ip_vs_wrr,ip_vs_sh,ip_tables,ip6_tables,netlink_diag,nf_nat,overlay,br_netfilter
+    raw.lxc: |
+      lxc.mount.auto=proc:rw sys:rw cgroup:rw
+      lxc.cgroup.devices.allow=a
+      lxc.cap.drop=
+    security.nesting: "true"
+  description: Default LXD profile
+  devices:
+    eth0:
+      name: eth0
+      network: lxdbr0
+      type: nic
+    root:
+      path: /
+      pool: default
+      type: disk
+  name: default
+projects:
+- config:
+    features.images: "true"
+    features.networks: "true"
+    features.profiles: "true"
+    features.storage.volumes: "true"
+  description: Default LXD project
+  name: default


### PR DESCRIPTION
Description:

This PR refactors install-lxd.sh to support dynamic initialization based on the execution environment and architecture.

**Changes:**

- **Environment Detection:**  Added logic to check `systemd-detect-virt` or `/proc/1/environ` to distinguish between `host` and `container`.
- **New Assets:**  Added granular preseed YAML files for `x86_64`, `ppc64le`, and `s390x`:

  - `_host`: Uses LVM storage and NAT networking.
  - `_container`: Uses `dir` driver and bridged networking (nested support).
- **Script Updates:**  Updated CentOS and Ubuntu build scripts to select the correct config file (`lxd_init_${ENV_TYPE}_${ARCH}.yml`) and use explicit `/snap/bin/lxd` paths.

Fixes: #9 