### PR TITLE
Fix DNS resolution issues in Docker when running in LXD containers

### DIFF
--- a/images/ubuntu/scripts/build/install-docker.sh
+++ b/images/ubuntu/scripts/build/install-docker.sh
@@ -102,7 +102,9 @@ cat << EOF > /etc/docker/daemon.json
   "storage-driver": "overlay2",
   "exec-opts": [
     "native.cgroupdriver=systemd"
-  ]
+  ],
+  "mtu": 1460,
+  "dns": ["8.8.8.8", "1.1.1.1"]
 }
 EOF
 


### PR DESCRIPTION
This pull request enhances network configuration and resolves DNS issues in Docker, particularly when running in LXD containers. The changes include additional netfilter connection tracking settings, disabling bridge netfilter to prevent DNS problems, and configuring fallback DNS servers in Docker daemon.