### PR TITLE
Add GitHub API authentication to avoid rate limiting

### DIFF
--- a/images/centos/scripts/build/configure-image-data.sh
+++ b/images/centos/scripts/build/configure-image-data.sh
@@ -20,10 +20,10 @@ REPO_OWNER="IBM"
 REPO_NAME="action-runner-image-pz"
 BRANCH="main"
 
-api_release_response=$(curl -s "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest")
+api_release_response=$(curl -s ${GITHUB_TOKEN:+-H "Authorization: Bearer ${GITHUB_TOKEN}"} "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest")
 git_tag=$(echo "$api_release_response" | jq -r .tag_name)
 
-build_sha=$(curl -s "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/commits/${BRANCH}" | jq -r .sha)
+build_sha=$(curl -s ${GITHUB_TOKEN:+-H "Authorization: Bearer ${GITHUB_TOKEN}"} "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/commits/${BRANCH}" | jq -r .sha)
 
 github_url="https://github.com/${REPO_OWNER}/${REPO_NAME}/blob/${BRANCH}/images"
 software_url="${github_url}/centos/toolsets/toolset-${image_version_major}${image_version_minor}.json"

--- a/images/centos/scripts/build/install-docker.sh
+++ b/images/centos/scripts/build/install-docker.sh
@@ -123,7 +123,7 @@ if [[ "$ARCH" != "ppc64le" && "$ARCH" != "s390x" ]]; then
 
     # Download amazon-ecr-credential-helper
     aws_latest_release_url="https://api.github.com/repos/awslabs/amazon-ecr-credential-helper/releases/latest"
-    aws_helper_url=$(curl -fsSL "${aws_latest_release_url}" | jq -r '.body' | awk -v arch="$package_arch" -F'[()]' '$0 ~ "linux-" arch {print $2}')
+    aws_helper_url=$(curl -fsSL ${GITHUB_TOKEN:+-H "Authorization: Bearer ${GITHUB_TOKEN}"} "${aws_latest_release_url}" | jq -r '.body' | awk -v arch="$package_arch" -F'[()]' '$0 ~ "linux-" arch {print $2}')
     aws_helper_binary_path=$(download_with_retry "$aws_helper_url")
 
     # Supply chain security - amazon-ecr-credential-helper

--- a/images/centos/scripts/build/install-zstd.sh
+++ b/images/centos/scripts/build/install-zstd.sh
@@ -9,7 +9,7 @@
 source "$HELPER_SCRIPTS"/install.sh
 
 # Download zstd
-release_tag=$(curl -fsSL https://api.github.com/repos/facebook/zstd/releases/latest | jq -r '.tag_name')
+release_tag=$(curl -fsSL ${GITHUB_TOKEN:+-H "Authorization: Bearer ${GITHUB_TOKEN}"} https://api.github.com/repos/facebook/zstd/releases/latest | jq -r '.tag_name')
 release_name="zstd-${release_tag//v}"
 download_url="https://github.com/facebook/zstd/releases/download/${release_tag}/${release_name}.tar.gz"
 archive_path=$(download_with_retry "${download_url}")

--- a/images/centos/scripts/helpers/install.sh
+++ b/images/centos/scripts/helpers/install.sh
@@ -61,7 +61,7 @@ get_github_releases_by_version() {
 
     page_size="100"
 
-    json=$(curl -fsSL "https://api.github.com/repos/${repo}/releases?per_page=${page_size}")
+    json=$(curl -fsSL ${GITHUB_TOKEN:+-H "Authorization: Bearer ${GITHUB_TOKEN}"} "https://api.github.com/repos/${repo}/releases?per_page=${page_size}")
 
     if [[ -z "$json" ]]; then
         echo "Failed to get releases" >&2

--- a/images/ubuntu/scripts/build/configure-image-data.sh
+++ b/images/ubuntu/scripts/build/configure-image-data.sh
@@ -21,10 +21,10 @@ REPO_OWNER="IBM"
 REPO_NAME="action-runner-image-pz"
 BRANCH="main"
 
-api_release_response=$(curl -s "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest")
+api_release_response=$(curl -s ${GITHUB_TOKEN:+-H "Authorization: Bearer ${GITHUB_TOKEN}"} "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest")
 git_tag=$(echo "$api_release_response" | jq -r .tag_name)
 
-build_sha=$(curl -s "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/commits/${BRANCH}" | jq -r .sha)
+build_sha=$(curl -s ${GITHUB_TOKEN:+-H "Authorization: Bearer ${GITHUB_TOKEN}"} "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/commits/${BRANCH}" | jq -r .sha)
 
 github_url="https://github.com/${REPO_OWNER}/${REPO_NAME}/blob/${BRANCH}/images"
 software_url="${github_url}/ubuntu/toolsets/toolset-${image_version_major}${image_version_minor}.json"

--- a/images/ubuntu/scripts/build/install-codeql-bundle.sh
+++ b/images/ubuntu/scripts/build/install-codeql-bundle.sh
@@ -25,7 +25,7 @@ case "$ARCH" in
 esac
 
 # Retrieve the latest major version of the CodeQL Action to use in the base URL for downloading the bundle.
-releases=$(curl -s "https://api.github.com/repos/github/codeql-action/releases")
+releases=$(curl -s ${GITHUB_TOKEN:+-H "Authorization: Bearer ${GITHUB_TOKEN}"} "https://api.github.com/repos/github/codeql-action/releases")
 
 # Get the release tags starting with v[0-9] and sort them in descending order, then parse the first one to get the major version.
 codeql_action_latest_major_version=$(echo "$releases" |

--- a/images/ubuntu/scripts/build/install-docker.sh
+++ b/images/ubuntu/scripts/build/install-docker.sh
@@ -137,7 +137,7 @@ if [[ "$ARCH" != "ppc64le" && "$ARCH" != "s390x" ]]; then
     
     # Download amazon-ecr-credential-helper
     aws_latest_release_url="https://api.github.com/repos/awslabs/amazon-ecr-credential-helper/releases/latest"
-    aws_helper_url=$(curl -fsSL "${aws_latest_release_url}" | jq -r '.body' | awk -v arch="$package_arch" -F'[()]' '$0 ~ "linux-" arch {print $2}')
+    aws_helper_url=$(curl -fsSL ${GITHUB_TOKEN:+-H "Authorization: Bearer ${GITHUB_TOKEN}"} "${aws_latest_release_url}" | jq -r '.body' | awk -v arch="$package_arch" -F'[()]' '$0 ~ "linux-" arch {print $2}')
     aws_helper_binary_path=$(download_with_retry "$aws_helper_url")
 
     # Supply chain security - amazon-ecr-credential-helper

--- a/images/ubuntu/scripts/build/install-nvm.sh
+++ b/images/ubuntu/scripts/build/install-nvm.sh
@@ -12,7 +12,7 @@ export NVM_DIR="/etc/skel/.nvm"
 mkdir -p "$NVM_DIR"
 
 if [ ! -f "$NVM_DIR/nvm.sh" ]; then
-    nvm_version=$(curl -fsSL https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r '.tag_name')
+    nvm_version=$(curl -fsSL ${GITHUB_TOKEN:+-H "Authorization: Bearer ${GITHUB_TOKEN}"} https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r '.tag_name')
     curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/"$nvm_version"/install.sh | bash
 else
     echo "NVM already installed at $NVM_DIR. Skipping installation."

--- a/images/ubuntu/scripts/build/install-swift.sh
+++ b/images/ubuntu/scripts/build/install-swift.sh
@@ -21,7 +21,7 @@ esac
 
 # Install
 image_label="ubuntu$(lsb_release -rs)"
-swift_version=$(curl -fsSL "https://api.github.com/repos/apple/swift/releases/latest" | jq -r '.tag_name | match("[0-9.]+").string')
+swift_version=$(curl -fsSL ${GITHUB_TOKEN:+-H "Authorization: Bearer ${GITHUB_TOKEN}"} "https://api.github.com/repos/apple/swift/releases/latest" | jq -r '.tag_name | match("[0-9.]+").string')
 swift_release_name="swift-${swift_version}-RELEASE-${image_label}"
 
 archive_url="https://swift.org/builds/swift-${swift_version}-release/${image_label//./}/swift-${swift_version}-RELEASE/${swift_release_name}.tar.gz"

--- a/images/ubuntu/scripts/build/install-zstd.sh
+++ b/images/ubuntu/scripts/build/install-zstd.sh
@@ -10,7 +10,7 @@
 source "$HELPER_SCRIPTS"/install.sh
 
 # Download zstd
-release_tag=$(curl -fsSL https://api.github.com/repos/facebook/zstd/releases/latest | jq -r '.tag_name')
+release_tag=$(curl -fsSL ${GITHUB_TOKEN:+-H "Authorization: Bearer ${GITHUB_TOKEN}"} https://api.github.com/repos/facebook/zstd/releases/latest | jq -r '.tag_name')
 release_name="zstd-${release_tag//v}"
 download_url="https://github.com/facebook/zstd/releases/download/${release_tag}/${release_name}.tar.gz"
 archive_path=$(download_with_retry "${download_url}")

--- a/images/ubuntu/scripts/helpers/install.sh
+++ b/images/ubuntu/scripts/helpers/install.sh
@@ -61,7 +61,7 @@ get_github_releases_by_version() {
 
     page_size="100"
 
-    json=$(curl -fsSL "https://api.github.com/repos/${repo}/releases?per_page=${page_size}")
+    json=$(curl -fsSL ${GITHUB_TOKEN:+-H "Authorization: Bearer ${GITHUB_TOKEN}"} "https://api.github.com/repos/${repo}/releases?per_page=${page_size}")
 
     if [[ -z "$json" ]]; then
         echo "Failed to get releases" >&2

--- a/scripts/helpers/run_script.sh
+++ b/scripts/helpers/run_script.sh
@@ -9,6 +9,11 @@ run_script() {
     # Initialize an empty array to store the environment variables
     local env_vars=()
 
+    # Always include GITHUB_TOKEN if it's set in the environment
+    if [[ -n "${GITHUB_TOKEN}" ]]; then
+        env_vars+=("GITHUB_TOKEN=${GITHUB_TOKEN}")
+    fi
+
     # Loop through the environment variable names and construct the env_vars array
     for var_name in "$@"; do
         if [[ -n "${!var_name}" ]]; then

--- a/scripts/lxd_container.sh
+++ b/scripts/lxd_container.sh
@@ -223,7 +223,7 @@ build_image() {
   msg "Running setup_install.sh (as root)"
   # shellcheck disable=SC1073
   # shellcheck disable=SC2154
-  if ! lxc exec "${BUILD_CONTAINER}" --user 0 --group 0 -- \
+  if ! lxc exec "${BUILD_CONTAINER}" --user 0 --group 0 ${GITHUB_TOKEN:+--env GITHUB_TOKEN="${GITHUB_TOKEN}"} -- \
     bash -c 'exec "$@"' _ "${helper_script_folder}/setup_install.sh" "${clean_args[@]}" "${forward_args[@]}"; then
 
     msg "!!! The installation script inside the container failed. Triggering cleanup. !!!" >&2

--- a/scripts/lxd_vm.sh
+++ b/scripts/lxd_vm.sh
@@ -243,7 +243,7 @@ build_image() {
   msg "Running setup_install.sh (as root)"
   # shellcheck disable=SC1073
   # shellcheck disable=SC2154
-  if ! lxc exec "${BUILD_CONTAINER}" --user 0 --group 0 -- \
+  if ! lxc exec "${BUILD_CONTAINER}" --user 0 --group 0 ${GITHUB_TOKEN:+--env GITHUB_TOKEN="${GITHUB_TOKEN}"} -- \
     bash -c 'exec "$@"' _ "${helper_script_folder}/setup_install.sh" "${clean_args[@]}" "${forward_args[@]}"; then
 
     msg "!!! The installation script inside the container failed. Triggering cleanup. !!!" >&2


### PR DESCRIPTION
This pull request adds GitHub API authentication support to all GitHub API calls throughout the build scripts. When a `GITHUB_TOKEN` environment variable is present, it will be used to authenticate API requests, helping to avoid GitHub API rate limiting issues during image builds.