### PR TITLE
Fix: Disable snap and LXD installation for VM setup and add runner upgrade documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This repository also includes source code to create VM images for GitHub-hosted 
     - [run.sh](#runsh)
     - [Key Features](#key-features)
 - [Usage](#usage)
+- [Upgrading Runner Binary (VM/Host Machine)](#upgrading-runner-binary-vmhost-machine)
 - [Setup Options](#setup-options)
     - [Main Menu](#main-menu)
     - [OS and Version Selection](#os-and-version-selection)
@@ -83,6 +84,26 @@ This runner image supports multiple environments on IBM hardware for a seamless 
     - Select your environment (**VM**, **LXD Container**, **LXD VM**, **Docker**, or **Podman**).
     - Choose your OS and version.
     - Specify the setup type (**Minimal** or **Complete**).
+
+---
+
+## **Upgrading Runner Binary (VM/Host Machine)**
+
+**This upgrade feature is specifically designed for VM (host machine) setups.** For container-based or LXD-based deployments, please rebuild the image instead.
+
+If you need to upgrade the GitHub Actions runner binary to the latest version on your VM or host machine, simply rerun the setup script:
+
+```bash
+bash run.sh
+```
+
+The script will automatically:
+- Detect the existing runner installation on the host
+- Download and install the latest runner binary
+- Fix any configuration issues
+- Preserve your existing runner registration and settings
+
+**Note**: For VM (host machine) setups, snap and LXD installation are disabled by default to avoid conflicts. The upgrade process will maintain this configuration.
 
 ---
 

--- a/run.sh
+++ b/run.sh
@@ -71,6 +71,10 @@ run_setup() {
     # Use an array for safer argument passing
     local script_args=("${os}" "${version}" "${worker_arg}" "${arch_arg}" "${setup_type}")
 
+    if [[ "$env" == "vm" ]]; then
+        script_args=("${script_args[@]}" "--skip-snap-lxd")
+    fi
+    
     # The script to be run inside the new shell.
     # It sources the target script and passes along all of its own arguments ("$@").
     local inner_script=". 'scripts/${env}.sh' \"\$@\""


### PR DESCRIPTION
This PR fixes issues encountered when rerunning `run.sh` on host VMs due to snap LXD setup conflicts. It also adds comprehensive documentation for upgrading runner binaries.

## Problem Solved
Previously, rerunning `run.sh` on host VMs would fail due to snap LXD setup conflicts. This fix allows users to:
- Safely rerun the script to upgrade runner binaries
- Avoid installation conflicts on host machines
- Maintain existing configurations during upgrades

## Testing
- Verified that VM setup skips snap and LXD installation
- Confirmed that rerunning the script successfully upgrades runner binaries
- Validated that existing runner configurations are preserved

Fixes: #38 
