### PR TITLE
fix(maven-version): update maven to 3.9.16 across all toolsets

### DIFF
--- a/images/centos/toolsets/toolset-10.json
+++ b/images/centos/toolsets/toolset-10.json
@@ -71,7 +71,7 @@
     "java": {
         "default": "17",
         "versions": [ "11", "17", "21", "25"],
-        "maven": "3.9.15"
+        "maven": "3.9.16"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-11076708_latest.zip",

--- a/images/centos/toolsets/toolset-9.json
+++ b/images/centos/toolsets/toolset-9.json
@@ -71,7 +71,7 @@
     "java": {
         "default": "17",
         "versions": [ "11", "17", "21", "25"],
-        "maven": "3.9.15"
+        "maven": "3.9.16"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-11076708_latest.zip",

--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -73,7 +73,7 @@
     "java": {
         "default": "11",
         "versions": ["11", "17", "21", "25"],
-        "maven": "3.9.15"
+        "maven": "3.9.16"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-9477386_latest.zip",

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -71,7 +71,7 @@
     "java": {
         "default": "17",
         "versions": [ "11", "17", "21", "25"],
-        "maven": "3.9.15"
+        "maven": "3.9.16"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-11076708_latest.zip",


### PR DESCRIPTION
This pull request updates Apache Maven to version 3.9.16 across all toolset configurations for both CentOS and Ubuntu images.