### PR TITLE
Fix idempotency check to distinguish between container and VM images

### DIFF
--- a/scripts/lxd_container.sh
+++ b/scripts/lxd_container.sh
@@ -138,6 +138,7 @@ build_image() {
   # shellcheck disable=SC2154
   EXISTING_IMAGE_JSON=$(lxc image list --format=json | jq -r --arg commit "${BUILD_SHA}" --arg os "${clean_args[0]}" --arg ver "${clean_args[1]}" --arg setup "${clean_args[4]}" \
     '.[] | select(
+        .type == "container" and
         .properties["properties.build.commit"] == $commit and 
         .properties["properties.build.os"] == $os and 
         .properties["properties.build.version"] == $ver and 

--- a/scripts/lxd_vm.sh
+++ b/scripts/lxd_vm.sh
@@ -309,6 +309,7 @@ build_image() {
   # shellcheck disable=SC2154
   EXISTING_IMAGE_JSON=$(lxc image list --format=json | jq -r --arg commit "${BUILD_SHA}" --arg os "${clean_args[0]}" --arg ver "${clean_args[1]}" --arg setup "${clean_args[4]}" \
     '.[] | select(
+        .type == "virtual-machine" and
         .properties["properties.build.commit"] == $commit and 
         .properties["properties.build.os"] == $os and 
         .properties["properties.build.version"] == $ver and 


### PR DESCRIPTION
### Summary
- Add .type filter to the idempotency check's jq query in both lxd_container.sh and lxd_vm.sh to prevent cross-matching between container and VM images. 
- Make lxd_vm.sh executable to match lxd_container.sh.

### Problem
- The idempotency check queries LXD images by commit, OS, version, and setup — but doesn't filter by image type. On hosts that build both containers and VMs, the check could match a VM image when running a container build (or vice versa), incorrectly skipping the build.

### Fix
- Added .type == "container" and .type == "virtual-machine" filters to the respective scripts so each builder only matches images of its own type.