### PR TITLE
Sync VM filesystem before snapshot to prevent data loss

### DIFF
--- a/scripts/lxd_vm.sh
+++ b/scripts/lxd_vm.sh
@@ -447,6 +447,10 @@ build_image() {
       fi
   fi
 
+  # Flush VM filesystem cache to ensure all writes are persisted before snapshot
+  msg "Syncing VM filesystem to disk."
+  lxc exec "${BUILD_VM}" -- sync
+
   msg "Runner build complete."
 
   # Snapshotting (VM Level) ---


### PR DESCRIPTION
## Summary
Add filesystem sync before VM snapshot to prevent data loss. Late-stage file writes (e.g., /etc/sudoers.d/runner) can remain in the guest VM's page cache when `lxc snapshot` captures the virtual disk. This causes those writes to be silently lost in the published image. Adding `sync` inside the VM before snapshotting ensures all pending writes are flushed to the virtual disk.

## How it was found
VM images were missing passwordless sudo for the runner user. The sudoers file was written correctly during the build (confirmed via build logs), but was empty or absent when launching a VM from the published image. Disabling cloud-init confirmed the file was never in the image. A manual test with `sync` before snapshot resolved it.