### PR TITLE
fix: anchor ORAS checksum regex to prevent false match on .sbom.json

### DIFF
--- a/images/ubuntu/scripts/build/install-oras-cli.sh
+++ b/images/ubuntu/scripts/build/install-oras-cli.sh
@@ -27,7 +27,7 @@ archive_path=$(download_with_retry "$download_url")
 
 # Supply chain security - ORAS CLI
 hash_url=$(resolve_github_release_asset_url "oras-project/oras" "endswith(\"checksums.txt\")" "latest")
-external_hash=$(get_checksum_from_url "${hash_url}" "linux_${package_arch}.tar.gz" "SHA256")
+external_hash=$(get_checksum_from_url "${hash_url}" "linux_${package_arch}.tar.gz$" "SHA256")
 use_checksum_comparison "$archive_path" "${external_hash}"
 
 # Unzip ORAS CLI


### PR DESCRIPTION
## Problem

Ubuntu image builds are failing during the ORAS CLI installation step with:

```text
Found multiple lines matching file name linux_ppc64le.tar.gz in checksum file.
!!! The installation script inside the container failed. Triggering cleanup. !!!
ERROR: Build failed for 22.04 [default]
```

## Root Cause

The pattern passed to `get_checksum_from_url` in `install-oras-cli.sh` was missing an end-of-line anchor:

```bash
# Before (buggy)
external_hash=$(get_checksum_from_url "${hash_url}" "linux_${package_arch}.tar.gz" "SHA256")
```

The ORAS `checksums.txt` file contains multiple entries for each architecture:

```text
abc123...  oras_1.3.3_linux_ppc64le.tar.gz
def456...  oras_1.3.3_linux_ppc64le.tar.gz.sbom.json
```

Without the `$` end-of-line anchor, both entries match the regex pattern, causing `get_checksum_from_url` to find multiple results and abort the installation.

## Fix

Add an end-of-line anchor to ensure only the archive checksum entry is matched:

```bash
# After (fixed)
external_hash=$(get_checksum_from_url "${hash_url}" "linux_${package_arch}.tar.gz$" "SHA256")
```

## Impact

This issue affects all supported architectures:

- `amd64`
- `arm64`
- `ppc64le`
- `s390x`

The fix ensures that only the intended `.tar.gz` artifact is matched and prevents false positives from associated `.sbom.json` entries.

## Notes

1. This issue has already been fixed in the upstream `actions/runner-images` repository.
2. Cherry-picked from commit `ce10250` on branch `feat/incus-vm-support`.
3. No functional changes beyond correcting checksum selection during ORAS CLI installation.