### PR TITLE
Feat/incus container support

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -78,7 +78,10 @@ run_setup() {
     
     # The script to be run inside the new shell.
     # It sources the target script and passes along all of its own arguments ("$@").
-    local inner_script=". 'scripts/${env}.sh' \"\$@\""
+    # umask 0022 is required: CIS-hardened hosts set UMASK 027 in /etc/login.defs
+    # which sudo inherits. distrobuilder runs apt as the unprivileged _apt user
+    # and it cannot traverse directories created with 0750 permissions.
+    local inner_script="umask 0022 && . 'scripts/${env}.sh' \"\$@\""
 
     # Execute using sudo bash -c, preserving GITHUB_TOKEN if set
     # The first argument after the script string ('bash') becomes $0 inside the new shell.

--- a/scripts/incus_container.sh
+++ b/scripts/incus_container.sh
@@ -17,16 +17,21 @@ msg() {
 ensure_incus() {
     echo "Ensuring Incus is installed and configured..."
     
-    # Always run install-incus.sh - it handles:
-    # 1. Installation (if not installed)
-    # 2. Configuration (if not configured)
-    # 3. Base image import (at the end)
-    # The script has built-in idempotency checks
-    run_script "${HOST_INSTALLER_SCRIPT_FOLDER}/install-incus.sh" "HELPER_SCRIPTS" "INSTALLER_SCRIPT_FOLDER" "ARCH"
+    # Check if we should skip installation
+    if [[ "${SKIP_SNAP_LXD}" == "true" ]]; then
+        echo "Skipping Incus installation (--skip-snap-lxd flag set)"
+    else
+        # Run install-incus.sh - it handles:
+        # 1. Installation (if not installed)
+        # 2. Configuration (if not configured)
+        # 3. Base image import (at the end)
+        # The script has built-in idempotency checks
+        run_script "${HOST_INSTALLER_SCRIPT_FOLDER}/install-incus.sh" "HELPER_SCRIPTS" "INSTALLER_SCRIPT_FOLDER" "ARCH"
+    fi
     
     # Verify Incus is working
     if ! command -v incus &> /dev/null; then
-        echo "Error: Incus installation failed."
+        echo "Error: Incus is not installed."
         exit 1
     fi
     
@@ -330,18 +335,26 @@ run() {
   ensure_incus "$@"
   
   # After Incus is ready, check and import base images if needed
-  # This runs in the main script context, so interactive prompts work
   echo ""
-  echo "Checking for Ubuntu base images..."
-  
-  if incus image list --format=csv | grep -q "ubuntu-22.04\|ubuntu-24.04"; then
-    echo "Ubuntu base images found. Skipping import."
+  echo "Checking for Ubuntu ${IMAGE_VERSION} base container image..."
+
+  local BASE_ALIAS="ubuntu-${IMAGE_VERSION}"
+
+  if incus image info "${BASE_ALIAS}" &>/dev/null; then
+    echo "Base image '${BASE_ALIAS}' found. Skipping import."
   else
-    echo "No Ubuntu base images found. Starting import..."
-    # Source and call the import function
+    echo "Base image '${BASE_ALIAS}' not found. Starting import..."
     # shellcheck disable=SC1091
     source "${HELPERS_DIR}/import_ubuntu_base_images.sh"
-    import_ubuntu_base_images
+    if ! import_ubuntu_base_images "container" "${IMAGE_VERSION}"; then
+      echo "Error: Failed to import base image '${BASE_ALIAS}'. Aborting." >&2
+      return 1
+    fi
+    if ! incus image info "${BASE_ALIAS}" &>/dev/null; then
+      echo "Error: Base image '${BASE_ALIAS}' not found in Incus after import. Aborting." >&2
+      return 1
+    fi
+    echo "Base image '${BASE_ALIAS}' confirmed in Incus."
   fi
   
   # Now build the container image
@@ -353,6 +366,9 @@ prolog() {
   PATH=/usr/local/bin:${PATH}
   EXPORT="/opt/distro"
   HOST_OS_NAME=$(awk -F= '/^NAME/{print $2}' /etc/os-release | tr -d '"' | tr '[:upper:]' '[:lower:]' | awk '{print $1}')
+  # Map OS families - Fedora/RHEL/AlmaLinux/Rocky use CentOS scripts
+  [[ "$HOST_OS_NAME" =~ ^(fedora|rhel|almalinux|rocky|red)$ ]] && HOST_OS_NAME="centos"
+  [[ "$HOST_OS_NAME" =~ ^(debian)$ ]] && HOST_OS_NAME="ubuntu"
   # shellcheck disable=SC2034
   # shellcheck disable=SC2002
   HOST_OS_VERSION=$(cat /etc/os-release | grep -E 'VERSION_ID' | cut -d'=' -f2 | tr -d '"')
@@ -369,3 +385,5 @@ prolog
 run "$@"
 RC=$?
 exit ${RC}
+
+

--- a/scripts/incus_container.sh
+++ b/scripts/incus_container.sh
@@ -18,8 +18,8 @@ ensure_incus() {
     echo "Ensuring Incus is installed and configured..."
     
     # Check if we should skip installation
-    if [[ "${SKIP_SNAP_LXD}" == "true" ]]; then
-        echo "Skipping Incus installation (--skip-snap-lxd flag set)"
+    if [[ "${SKIP_SNAP_INCUS}" == "true" ]]; then
+        echo "Skipping Incus installation (--skip-snap-incus flag set)"
     else
         # Run install-incus.sh - it handles:
         # 1. Installation (if not installed)

--- a/scripts/lxd_container.sh
+++ b/scripts/lxd_container.sh
@@ -339,6 +339,9 @@ prolog() {
   PATH=/snap/bin:${PATH}
   EXPORT="/opt/distro"
   HOST_OS_NAME=$(awk -F= '/^NAME/{print $2}' /etc/os-release | tr -d '"' | tr '[:upper:]' '[:lower:]' | awk '{print $1}')
+  # Map OS families - Fedora/RHEL/AlmaLinux/Rocky use CentOS scripts
+  [[ "$HOST_OS_NAME" =~ ^(fedora|rhel|almalinux|rocky|red)$ ]] && HOST_OS_NAME="centos"
+  [[ "$HOST_OS_NAME" =~ ^(debian)$ ]] && HOST_OS_NAME="ubuntu"
   # shellcheck disable=SC2034
   # shellcheck disable=SC2002
   HOST_OS_VERSION=$(cat /etc/os-release | grep -E 'VERSION_ID' | cut -d'=' -f2 | tr -d '"')

--- a/scripts/lxd_vm.sh
+++ b/scripts/lxd_vm.sh
@@ -540,6 +540,9 @@ prolog() {
   PATH=/snap/bin:${PATH}
   EXPORT="/opt/distro"
   HOST_OS_NAME=$(awk -F= '/^NAME/{print $2}' /etc/os-release | tr -d '"' | tr '[:upper:]' '[:lower:]' | awk '{print $1}')
+  # Map OS families - Fedora/RHEL/AlmaLinux/Rocky use CentOS scripts
+  [[ "$HOST_OS_NAME" =~ ^(fedora|rhel|almalinux|rocky|red)$ ]] && HOST_OS_NAME="centos"
+  [[ "$HOST_OS_NAME" =~ ^(debian)$ ]] && HOST_OS_NAME="ubuntu"
   # shellcheck disable=SC2034
   # shellcheck disable=SC2002
   HOST_OS_VERSION=$(cat /etc/os-release | grep -E 'VERSION_ID' | cut -d'=' -f2 | tr -d '"')


### PR DESCRIPTION
## Summary

This PR introduces Incus container image build support and integrates it into the existing build workflow. It adds a dedicated Incus container build pipeline, updates the interactive build menu, strengthens safeguards around mixed LXD/Incus environments, and resolves package installation issues observed on minimal Ubuntu 22.04 systems.



## Changes

### 1. Add Incus Container Build Pipeline

**New file**

- `scripts/incus_container.sh`

Introduces a complete Incus container image build workflow that:

- Builds Incus-based container images using the standardized image build process
- Implements idempotent commit-hash stamping to avoid unnecessary rebuilds
- Uses file locking to protect shared snapshot publication operations
- Validates image type inputs before execution
- Aligns Incus container builds with existing image generation workflows

### 2. Update Build Menu Integration

**Modified file**

- `run.sh`

Updates the main entry point to:

- Set `umask 0022` to ensure compatibility with CIS-hardened environments
- Add menu wiring and 