### PR TITLE
Feat/incus base image import

### DIFF
--- a/scripts/helpers/import-incus-ubuntu-image.sh
+++ b/scripts/helpers/import-incus-ubuntu-image.sh
@@ -181,3 +181,4 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     
     import_incus_ubuntu_image "$@"
 fi
+

--- a/scripts/helpers/import_ubuntu_base_images.sh
+++ b/scripts/helpers/import_ubuntu_base_images.sh
@@ -2,36 +2,61 @@
 ################################################################################
 ##  File:  import_ubuntu_base_images.sh
 ##  Desc:  Architecture-aware Ubuntu base image import for Incus
-##  Usage: Source this file and call import_ubuntu_base_images
+##  Usage: Source this file and call import_ubuntu_base_images [container|vm] [version]
 ##         Automatically selects import method based on system architecture:
 ##         - x86_64/aarch64: Uses Incus image server (fast, pre-configured)
 ##         - ppc64le/s390x: Uses Distrobuilder (custom build required)
+##  Args:  $1 - Image type: "container" (default) or "vm"
+##         $2 - Ubuntu version: "22.04" or "24.04" (required)
 ################################################################################
 
 # Note: Do NOT use 'set -e' in sourced scripts as it affects the parent shell
 
 import_ubuntu_base_images() {
+    local IMAGE_TYPE="${1:-container}"  # Default to container if not specified
+    local VERSION="${2:-}"
     local ORIGINAL_DIR
     ORIGINAL_DIR=$(pwd)
     local SYSTEM_ARCH="${ARCH:-$(uname -m)}"
     local HELPERS_DIR="${HELPERS_DIR:-$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")}"
-    
+
+    # Validate image type
+    if [[ "$IMAGE_TYPE" != "container" ]] && [[ "$IMAGE_TYPE" != "vm" ]]; then
+        echo "Error: Invalid image type: $IMAGE_TYPE"
+        echo "Must be 'container' or 'vm'"
+        return 1
+    fi
+
+    # Validate version
+    if [[ "$VERSION" != "22.04" ]] && [[ "$VERSION" != "24.04" ]]; then
+        echo "Error: Invalid or missing Ubuntu version: '${VERSION}'"
+        echo "Must be 22.04 or 24.04"
+        return 1
+    fi
+
     echo ""
     echo "=========================================="
     echo " Ubuntu Base Image Import"
     echo "=========================================="
     echo ""
     echo "Detected system architecture: ${SYSTEM_ARCH}"
+    echo "Image type: ${IMAGE_TYPE}"
+    echo "Ubuntu version: ${VERSION}"
     echo ""
-    
+
     # Determine import method based on architecture
     local IMPORT_METHOD
     local METHOD_DESC
-    
+
     case "$SYSTEM_ARCH" in
         x86_64|aarch64)
-            IMPORT_METHOD="incus-server"
-            METHOD_DESC="Incus Image Server (fast, pre-configured images)"
+            if [[ "$IMAGE_TYPE" == "vm" ]]; then
+                IMPORT_METHOD="distrobuilder"
+                METHOD_DESC="Distrobuilder (VM images not available on Incus server)"
+            else
+                IMPORT_METHOD="incus-server"
+                METHOD_DESC="Incus Image Server (fast, pre-configured images)"
+            fi
             ;;
         ppc64le|s390x)
             IMPORT_METHOD="distrobuilder"
@@ -44,118 +69,40 @@ import_ubuntu_base_images() {
             return 1
             ;;
     esac
-    
+
     echo "Import method: ${METHOD_DESC}"
     echo ""
-    echo "Choose Ubuntu version to import:"
-    echo "1) Ubuntu 22.04 LTS (Jammy)"
-    echo "2) Ubuntu 24.04 LTS (Noble)"
-    echo "3) Both versions"
-    echo "4) Skip (use existing images)"
-    echo ""
-    
-    read -r -p "Enter choice [1-4]: " version_choice
-    
-    case "$version_choice" in
-        1)
-            echo ""
-            if [ "$IMPORT_METHOD" = "incus-server" ]; then
-                echo "Importing Ubuntu 22.04 from Incus image server..."
-                # shellcheck disable=SC1090,SC1091
-                source "${HELPERS_DIR}/import-incus-ubuntu-image.sh"
-                if ! import_incus_ubuntu_image "22.04" "${SYSTEM_ARCH}"; then
-                    echo "Error: Failed to import Ubuntu 22.04"
-                    cd "$ORIGINAL_DIR" || return 1
-                    return 1
-                fi
-            else
-                echo "Building Ubuntu 22.04 with Distrobuilder..."
-                # shellcheck disable=SC1090,SC1091
-                source "${HELPERS_DIR}/build-distrobuilder-image.sh"
-                if ! build_distrobuilder_ubuntu_image "22.04"; then
-                    echo "Error: Failed to build Ubuntu 22.04"
-                    cd "$ORIGINAL_DIR" || return 1
-                    return 1
-                fi
-            fi
-            ;;
-        2)
-            echo ""
-            if [ "$IMPORT_METHOD" = "incus-server" ]; then
-                echo "Importing Ubuntu 24.04 from Incus image server..."
-                # shellcheck disable=SC1090,SC1091
-                source "${HELPERS_DIR}/import-incus-ubuntu-image.sh"
-                if ! import_incus_ubuntu_image "24.04" "${SYSTEM_ARCH}"; then
-                    echo "Error: Failed to import Ubuntu 24.04"
-                    cd "$ORIGINAL_DIR" || return 1
-                    return 1
-                fi
-            else
-                echo "Building Ubuntu 24.04 with Distrobuilder..."
-                # shellcheck disable=SC1090,SC1091
-                source "${HELPERS_DIR}/build-distrobuilder-image.sh"
-                if ! build_distrobuilder_ubuntu_image "24.04"; then
-                    echo "Error: Failed to build Ubuntu 24.04"
-                    cd "$ORIGINAL_DIR" || return 1
-                    return 1
-                fi
-            fi
-            ;;
-        3)
-            echo ""
-            if [ "$IMPORT_METHOD" = "incus-server" ]; then
-                echo "Importing Ubuntu 22.04 from Incus image server..."
-                # shellcheck disable=SC1090,SC1091
-                source "${HELPERS_DIR}/import-incus-ubuntu-image.sh"
-                if ! import_incus_ubuntu_image "22.04" "${SYSTEM_ARCH}"; then
-                    echo "Error: Failed to import Ubuntu 22.04"
-                    cd "$ORIGINAL_DIR" || return 1
-                    return 1
-                fi
-                echo ""
-                echo "Importing Ubuntu 24.04 from Incus image server..."
-                if ! import_incus_ubuntu_image "24.04" "${SYSTEM_ARCH}"; then
-                    echo "Error: Failed to import Ubuntu 24.04"
-                    cd "$ORIGINAL_DIR" || return 1
-                    return 1
-                fi
-            else
-                echo "Building Ubuntu 22.04 with Distrobuilder..."
-                # shellcheck disable=SC1090,SC1091
-                source "${HELPERS_DIR}/build-distrobuilder-image.sh"
-                if ! build_distrobuilder_ubuntu_image "22.04"; then
-                    echo "Error: Failed to build Ubuntu 22.04"
-                    cd "$ORIGINAL_DIR" || return 1
-                    return 1
-                fi
-                echo ""
-                echo "Building Ubuntu 24.04 with Distrobuilder..."
-                if ! build_distrobuilder_ubuntu_image "24.04"; then
-                    echo "Error: Failed to build Ubuntu 24.04"
-                    cd "$ORIGINAL_DIR" || return 1
-                    return 1
-                fi
-            fi
-            ;;
-        4)
-            echo ""
-            echo "Skipping image import. Using existing images."
-            ;;
-        *)
-            echo ""
-            echo "Invalid choice. Skipping image import."
+
+    local BUILD_VM="false"
+    [[ "$IMAGE_TYPE" == "vm" ]] && BUILD_VM="true"
+
+    if [ "$IMPORT_METHOD" = "incus-server" ]; then
+        # shellcheck disable=SC1090,SC1091
+        source "${HELPERS_DIR}/import-incus-ubuntu-image.sh"
+        echo "Importing Ubuntu ${VERSION} from Incus image server..."
+        if ! import_incus_ubuntu_image "${VERSION}" "${SYSTEM_ARCH}"; then
+            echo "Error: Failed to import Ubuntu ${VERSION}"
             cd "$ORIGINAL_DIR" || return 1
             return 1
-            ;;
-    esac
-    
+        fi
+    else
+        # shellcheck disable=SC1090,SC1091
+        source "${HELPERS_DIR}/build-distrobuilder-image.sh"
+        echo "Building Ubuntu ${VERSION} ${IMAGE_TYPE} with Distrobuilder..."
+        if ! build_distrobuilder_ubuntu_image "${VERSION}" "${SYSTEM_ARCH}" "$HOME/incus-images/official-ubuntu" "$BUILD_VM"; then
+            echo "Error: Failed to build Ubuntu ${VERSION} ${IMAGE_TYPE}"
+            cd "$ORIGINAL_DIR" || return 1
+            return 1
+        fi
+    fi
+
     cd "$ORIGINAL_DIR" || return 1
-    
+
     echo ""
     echo "=========================================="
     echo "Image import step completed successfully"
     echo "=========================================="
     echo ""
-    
+
     return 0
 }

--- a/scripts/helpers/setup_vars.sh
+++ b/scripts/helpers/setup_vars.sh
@@ -15,6 +15,7 @@ usage() {
     echo "Flags:"
     echo "  --lxd-debug             Enable LXD debug mode (non-ephemeral containers)"
     echo "  --skip-snap-lxd         Skip snap and lxd installation and configuration"
+    echo "  --skip-snap-incus       Skip Incus installation and configuration"
     echo "  --skip-lxd-img-export   Skip LXD image export"
     echo "  --skip-lxd-img-primer   Skip LXD image primer"
     echo "  --skip-lxd-publish      Skip LXD publish"
@@ -26,6 +27,7 @@ usage() {
     echo "  --skip-incus-publish    Skip Incus publish"
     echo "  --skip-incus-snapshot   Skip Incus snapshot"
     echo "  --delete-incus-img      Delete the existing Incus image before building"
+    echo "  --skip-incus-base-img   Skip building/importing the Incus base OS image"
     echo "  -h, --help              Show this help"
     echo ""
     # Use return 1 instead of exit 1 because this script is sourced
@@ -35,6 +37,7 @@ usage() {
 # Initialize Defaults ---
 LXD_DEBUG=false
 SKIP_SNAP_LXD=false
+SKIP_SNAP_INCUS=false
 SKIP_LXD_IMG_EXPORT=false
 SKIP_LXD_IMG_PRIMER=false
 SKIP_LXD_PUBLISH=false
@@ -46,6 +49,7 @@ SKIP_INCUS_IMG_PRIMER=false
 SKIP_INCUS_PUBLISH=false
 SKIP_INCUS_SNAPSHOT=false
 DELETE_INCUS_IMG=false
+SKIP_INCUS_BASE_IMG=false
 ARCH=${ARCH:-$(uname -m)}
 PATCH_FILE="${PATCH_FILE:-runner-sdk8-${ARCH}.patch}"
 
@@ -65,6 +69,11 @@ while [[ $# -gt 0 ]]; do
         --skip-snap-lxd)
             # shellcheck disable=SC2034
             SKIP_SNAP_LXD=true
+            forward_args+=("$1")
+            ;;
+        --skip-snap-incus)
+            # shellcheck disable=SC2034
+            SKIP_SNAP_INCUS=true
             forward_args+=("$1")
             ;;
         --skip-lxd-img-export)
@@ -120,6 +129,11 @@ while [[ $# -gt 0 ]]; do
         --delete-incus-img)
             # shellcheck disable=SC2034
             DELETE_INCUS_IMG=true
+            forward_args+=("$1")
+            ;;
+        --skip-incus-base-img)
+            # shellcheck disable=SC2034
+            SKIP_INCUS_BASE_IMG=true
             forward_args+=("$1")
             ;;
         -h|--help)


### PR DESCRIPTION
# Add architecture-aware base image import helpers for Incus containers

- import_ubuntu_base_images.sh / import-incus-ubuntu-image.sh: x86_64/aarch64 pull from Incus image server; ppc64le/s390x use distrobuilder
- Per-arch container init YAML assets (ppc64le, s390x, x86_64)
- setup_vars.sh: Incus-specific environment variables
