### PR TITLE
Feat/incus distrobuilder patches

### DIFF
--- a/patches/distrobuilder.patch
+++ b/patches/distrobuilder.patch
@@ -1,0 +1,322 @@
+diff --git a/distrobuilder/main_incus.go b/distrobuilder/main_incus.go
+index adf8c34..82ded17 100644
+--- a/distrobuilder/main_incus.go
++++ b/distrobuilder/main_incus.go
+@@ -12,6 +12,7 @@ import (
+ 
+ 	client "github.com/lxc/incus/v7/client"
+ 	"github.com/lxc/incus/v7/shared/api"
++	incusArch "github.com/lxc/incus/v7/shared/osarch"
+ 	"github.com/sirupsen/logrus"
+ 	"github.com/spf13/cobra"
+ 	"golang.org/x/sys/unix"
+@@ -327,7 +328,12 @@ func (c *cmdIncus) run(cmd *cobra.Command, args []string, overlayDir string) err
+ 
+ 		imgFile := filepath.Join(c.global.flagCacheDir, imgFilename)
+ 
+-		vm, err = newVM(c.global.ctx, imgFile, vmDir, c.global.definition.Targets.Incus.VM.Filesystem, c.global.definition.Targets.Incus.VM.Size)
++		archID, err := incusArch.ArchitectureID(c.global.definition.Image.Architecture)
++		if err != nil {
++			return fmt.Errorf("Failed to get architecture ID: %w", err)
++		}
++
++		vm, err = newVM(c.global.ctx, imgFile, vmDir, c.global.definition.Targets.Incus.VM.Filesystem, c.global.definition.Targets.Incus.VM.Size, archID)
+ 		if err != nil {
+ 			return fmt.Errorf("Failed to instantiate VM: %w", err)
+ 		}
+@@ -382,10 +388,13 @@ func (c *cmdIncus) run(cmd *cobra.Command, args []string, overlayDir string) err
+ 			return fmt.Errorf("Failed to find rootfs device UUID: %w", err)
+ 		}
+ 
++		loopEnv := fmt.Sprintf("%s=%s", shared.EnvLoopDevice, vm.getLoopDev())
++
+ 		c.global.ctx = context.WithValue(c.global.ctx, shared.ContextKeyEnviron,
+ 			[]string{
+ 				fmt.Sprintf("%s=%s", shared.EnvRootUUID, rootUUID),
+ 				fmt.Sprintf("%s=%s", shared.EnvRootPARTUUID, partUUID),
++				loopEnv,
+ 			})
+ 		// We cannot use Incus' rsync package as that uses the --delete flag which
+ 		// causes an issue due to the boot/efi directory being present.
+@@ -407,19 +416,35 @@ func (c *cmdIncus) run(cmd *cobra.Command, args []string, overlayDir string) err
+ 				Target: filepath.Join("/", "dev", filepath.Base(vm.getRootfsDevFile())),
+ 				Flags:  unix.MS_BIND,
+ 			},
+-			{
++		}
++
++		// Bind-mount the boot partition device into the chroot (if present).
++		if vm.getUEFIDevFile() != "" {
++			mounts = append(mounts, shared.ChrootMount{
+ 				Source: vm.getUEFIDevFile(),
+ 				Target: filepath.Join("/", "dev", filepath.Base(vm.getUEFIDevFile())),
+ 				Flags:  unix.MS_BIND,
+-			},
+-			{
++			})
++		}
++
++		if vm.architecture == incusArch.ARCH_64BIT_S390_BIG_ENDIAN && vm.getUEFIDevFile() != "" {
++			mounts = append(mounts, shared.ChrootMount{
++				Source: vm.getUEFIDevFile(),
++				Target: "/boot",
++				FSType: "ext4",
++				Flags:  0,
++				Data:   "",
++				IsDir:  true,
++			})
++		} else if vm.architecture != incusArch.ARCH_64BIT_POWERPC_LITTLE_ENDIAN && vm.getUEFIDevFile() != "" {
++			mounts = append(mounts, shared.ChrootMount{
+ 				Source: vm.getUEFIDevFile(),
+ 				Target: "/boot/efi",
+ 				FSType: "vfat",
+ 				Flags:  0,
+ 				Data:   "",
+ 				IsDir:  true,
+-			},
++			})
+ 		}
+ 	}
+ 
+@@ -573,7 +598,7 @@ func (c *cmdIncus) run(cmd *cobra.Command, args []string, overlayDir string) err
+ }
+ 
+ func (c *cmdIncus) checkVMDependencies() error {
+-	dependencies := []string{"btrfs", "mkfs.ext4", "mkfs.vfat", "qemu-img", "rsync", "sgdisk"}
++	dependencies := []string{"btrfs", "mkfs.ext4", "qemu-img", "rsync", "sgdisk"}
+ 
+ 	for _, dep := range dependencies {
+ 		_, err := exec.LookPath(dep)
+diff --git a/distrobuilder/vm.go b/distrobuilder/vm.go
+index 77a4fc0..cef283b 100644
+--- a/distrobuilder/vm.go
++++ b/distrobuilder/vm.go
+@@ -10,6 +10,7 @@ import (
+ 	"strconv"
+ 	"strings"
+ 
++	incusArch "github.com/lxc/incus/v7/shared/osarch"
+ 	incus "github.com/lxc/incus/v7/shared/util"
+ 	"golang.org/x/sys/unix"
+ 
+@@ -17,16 +18,17 @@ import (
+ )
+ 
+ type vm struct {
+-	imageFile  string
+-	loopDevice string
+-	rootFS     string
+-	rootfsDir  string
+-	bootfsDir  string
+-	size       uint64
+-	ctx        context.Context
++	imageFile    string
++	loopDevice   string
++	rootFS       string
++	rootfsDir    string
++	bootfsDir    string
++	size         uint64
++	ctx          context.Context
++	architecture int
+ }
+ 
+-func newVM(ctx context.Context, imageFile, rootfsDir, fs string, size uint64) (*vm, error) {
++func newVM(ctx context.Context, imageFile, rootfsDir, fs string, size uint64, architecture int) (*vm, error) {
+ 	if fs == "" {
+ 		fs = "ext4"
+ 	}
+@@ -39,7 +41,7 @@ func newVM(ctx context.Context, imageFile, rootfsDir, fs string, size uint64) (*
+ 		size = 4294967296
+ 	}
+ 
+-	return &vm{ctx: ctx, imageFile: imageFile, rootfsDir: rootfsDir, rootFS: fs, size: size}, nil
++	return &vm{ctx: ctx, imageFile: imageFile, rootfsDir: rootfsDir, rootFS: fs, size: size, architecture: architecture}, nil
+ }
+ 
+ func (v *vm) getLoopDev() string {
+@@ -121,10 +123,28 @@ func (v *vm) createEmptyDiskImage() error {
+ 
+ func (v *vm) createPartitions(args ...[]string) error {
+ 	if len(args) == 0 {
+-		args = [][]string{
+-			{"--zap-all"},
+-			{"--new=1::+100M", "-t 1:EF00"},
+-			{"--new=2::", "-t 2:8300"},
++		switch v.architecture {
++		case incusArch.ARCH_64BIT_POWERPC_LITTLE_ENDIAN:
++			// PReP boot partition (8 MiB, no filesystem) + Linux root
++			args = [][]string{
++				{"--zap-all"},
++				{"--new=1::+8M", "-t 1:4100"},
++				{"--new=2::", "-t 2:8300"},
++			}
++		case incusArch.ARCH_64BIT_S390_BIG_ENDIAN:
++			// Boot partition (500 MiB, ext4) + Linux root
++			args = [][]string{
++				{"--zap-all"},
++				{"--new=1::+500M", "-t 1:8300"},
++				{"--new=2::", "-t 2:8300"},
++			}
++		default:
++			// EFI System Partition (100 MiB, vfat) + Linux root
++			args = [][]string{
++				{"--zap-all"},
++				{"--new=1::+100M", "-t 1:EF00"},
++				{"--new=2::", "-t 2:8300"},
++			}
+ 		}
+ 	}
+ 
+@@ -210,7 +230,7 @@ func (v *vm) mountImage() error {
+ 	if err != nil {
+ 		return err
+ 	} else if num != 3 {
+-		return fmt.Errorf("Failed to list block devices")
++		return fmt.Errorf("Expected 3 block devices (loop + 2 partitions), got %d", num)
+ 	}
+ 
+ 	if !incus.PathExists(v.getUEFIDevFile()) {
+@@ -315,6 +335,16 @@ func (v *vm) createUEFIFS() error {
+ 		return errors.New("Disk image not mounted")
+ 	}
+ 
++	// ppc64le uses a raw PReP partition instead of a vfat ESP
++	if v.architecture == incusArch.ARCH_64BIT_POWERPC_LITTLE_ENDIAN {
++		return nil
++	}
++
++	// s390x uses an ext4 boot partition instead of a vfat ESP
++	if v.architecture == incusArch.ARCH_64BIT_S390_BIG_ENDIAN {
++		return shared.RunCommand(v.ctx, nil, nil, "mkfs.ext4", "-F", "-L", "boot", v.getUEFIDevFile())
++	}
++
+ 	return shared.RunCommand(v.ctx, nil, nil, "mkfs.vfat", "-F", "32", "-n", "UEFI", v.getUEFIDevFile())
+ }
+ 
+@@ -338,6 +368,23 @@ func (v *vm) mountUEFIPartition() error {
+ 		return errors.New("Disk image not mounted")
+ 	}
+ 
++	// ppc64le uses a raw PReP partition, no vfat filesystem to mount
++	if v.architecture == incusArch.ARCH_64BIT_POWERPC_LITTLE_ENDIAN {
++		return nil
++	}
++
++	// s390x uses an ext4 boot partition mounted at /boot
++	if v.architecture == incusArch.ARCH_64BIT_S390_BIG_ENDIAN {
++		v.bootfsDir = filepath.Join(v.rootfsDir, "boot")
++
++		err := os.MkdirAll(v.bootfsDir, 0o755)
++		if err != nil {
++			return fmt.Errorf("Failed to create directory %q: %w", v.bootfsDir, err)
++		}
++
++		return shared.RunCommand(v.ctx, nil, nil, "mount", "-t", "ext4", v.getUEFIDevFile(), v.bootfsDir, "-o", "discard")
++	}
++
+ 	v.bootfsDir = filepath.Join(v.rootfsDir, "boot", "efi")
+ 
+ 	err := os.MkdirAll(v.bootfsDir, 0o755)
+diff --git a/distrobuilder/vm_test.go b/distrobuilder/vm_test.go
+index b40129d..542cbd4 100644
+--- a/distrobuilder/vm_test.go
++++ b/distrobuilder/vm_test.go
+@@ -77,6 +77,8 @@ func TestLsblkOutput(t *testing.T) {
+ 	}{
+ 		{"DiskEmpty", [][]string{{"--zap-all"}}, 1},
+ 		{"UEFI", nil, 3},
++		{"PReP", [][]string{{"--zap-all"}, {"--new=1::+8M", "-t 1:4100"}, {"--new=2::", "-t 2:8300"}}, 3},
++		{"S390x", [][]string{{"--zap-all"}, {"--new=1::+50M", "-t 1:8300"}, {"--new=2::", "-t 2:8300"}}, 3},
+ 		{"MBR", [][]string{{"--new=1::"}, {"--gpttombr"}}, 2},
+ 	}
+ 
+diff --git a/generators/common.go b/generators/common.go
+index 66a7cc4..7dc52e1 100644
+--- a/generators/common.go
++++ b/generators/common.go
+@@ -11,6 +11,7 @@ type common struct {
+ 	cacheDir  string
+ 	sourceDir string
+ 	defFile   shared.DefinitionFile
++	def       shared.Definition
+ }
+ 
+ func (g *common) init(logger *logrus.Logger, cacheDir string, sourceDir string, defFile shared.DefinitionFile, def shared.Definition) {
+@@ -18,6 +19,7 @@ func (g *common) init(logger *logrus.Logger, cacheDir string, sourceDir string,
+ 	g.cacheDir = cacheDir
+ 	g.sourceDir = sourceDir
+ 	g.defFile = defFile
++	g.def = def
+ 
+ 	render := func(val string) string {
+ 		if !defFile.Pongo {
+diff --git a/generators/fstab.go b/generators/fstab.go
+index bb77e4b..1476807 100644
+--- a/generators/fstab.go
++++ b/generators/fstab.go
+@@ -6,6 +6,8 @@ import (
+ 	"os"
+ 	"path/filepath"
+ 
++	incusArch "github.com/lxc/incus/v7/shared/osarch"
++
+ 	"github.com/lxc/distrobuilder/v3/image"
+ 	"github.com/lxc/distrobuilder/v3/shared"
+ )
+@@ -28,10 +30,6 @@ func (g *fstab) RunIncus(img *image.IncusImage, target shared.DefinitionTargetIn
+ 
+ 	defer f.Close()
+ 
+-	content := `LABEL=rootfs  /         %s  %s  0 0
+-LABEL=UEFI    /boot/efi vfat  defaults  0 0
+-`
+-
+ 	fs := target.VM.Filesystem
+ 
+ 	if fs == "" {
+@@ -44,7 +42,23 @@ LABEL=UEFI    /boot/efi vfat  defaults  0 0
+ 		options = fmt.Sprintf("%s,subvol=@", options)
+ 	}
+ 
+-	_, err = fmt.Fprintf(f, content, fs, options)
++	// Determine the boot partition fstab entry based on architecture.
++	// s390x uses an ext4 /boot partition; ppc64le uses a raw PReP partition
++	// (no filesystem, no fstab entry); all others use a vfat /boot/efi ESP.
++	archID, _ := incusArch.ArchitectureID(g.def.Image.Architecture)
++
++	var bootEntry string
++
++	switch archID {
++	case incusArch.ARCH_64BIT_S390_BIG_ENDIAN:
++		bootEntry = "LABEL=boot    /boot     ext4  defaults  0 2\n"
++	case incusArch.ARCH_64BIT_POWERPC_LITTLE_ENDIAN:
++		// PReP partition has no filesystem; no fstab entry needed.
++	default:
++		bootEntry = "LABEL=UEFI    /boot/efi vfat  defaults  0 0\n"
++	}
++
++	_, err = fmt.Fprintf(f, "LABEL=rootfs  /         %s  %s  0 0\n%s", fs, options, bootEntry)
+ 	if err != nil {
+ 		return fmt.Errorf("Failed to write string to file %q: %w", filepath.Join(g.sourceDir, "etc/fstab"), err)
+ 	}
+diff --git a/shared/chroot.go b/shared/chroot.go
+index 619fa3f..18a865b 100644
+--- a/shared/chroot.go
++++ b/shared/chroot.go
+@@ -433,3 +433,4 @@ func populateDev() error {
+ 
+ 	return nil
+ }
++
+diff --git a/shared/util.go b/shared/util.go
+index 5526734..82ab121 100644
+--- a/shared/util.go
++++ b/shared/util.go
+@@ -25,6 +25,7 @@ const (
+ 	ContextKeyStderr  = ContextKey("stderr")
+ 	EnvRootUUID       = "DISTROBUILDER_ROOT_UUID"
+ 	EnvRootPARTUUID   = "DISTROBUILDER_ROOT_PARTUUID"
++	EnvLoopDevice     = "DISTROBUILDER_LOOP_DEVICE"
+ )
+ 
+ // EnvVariable represents a environment variable.

--- a/patches/lxc-ci.patch
+++ b/patches/lxc-ci.patch
@@ -1,0 +1,112 @@
+diff --git a/images/ubuntu.yaml b/images/ubuntu.yaml
+index 81be31e..1429e76 100644
+--- a/images/ubuntu.yaml
++++ b/images/ubuntu.yaml
+@@ -352,7 +352,9 @@ files:
+     network:
+       version: 2
+       ethernets:
+-        enp5s0:
++        id0:
++          match:
++            name: "en*"
+           dhcp4: true
+           dhcp-identifier: mac
+   types:
+@@ -498,6 +500,22 @@ packages:
+     types:
+     - vm
+ 
++  - packages:
++    - grub-ieee1275
++    action: install
++    architectures:
++    - ppc64el
++    types:
++    - vm
++
++  - packages:
++    - s390-tools
++    action: install
++    architectures:
++    - s390x
++    types:
++    - vm
++
+   - packages:
+     - shim-signed
+     action: install
+@@ -648,5 +666,72 @@ actions:
+ 
+    update-grub
+    sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" /boot/grub/grub.cfg
++  architectures:
++  - amd64
++  - arm64
++  types:
++  - vm
++
++- trigger: post-files
++  action: |-
++    #!/bin/sh
++    set -eux
++
++    # Install GRUB for PowerPC IEEE1275 (pSeries/PowerNV).
++    # Only Ubuntu 24.04+ (noble) is supported on ppc64le VM builds.
++    # Ubuntu 22.04 (jammy) ships GRUB 2.06 which fails to install in
++    # the distrobuilder chroot environment; 22.04 ppc64le VM is not
++    # supported.
++    LOOP_DEV="${DISTROBUILDER_LOOP_DEVICE}"
++    if [ -n "${LOOP_DEV}" ]; then
++      mkdir -p /boot/grub
++      echo "(hd0) ${LOOP_DEV}" > /boot/grub/device.map
++      # --skip-fs-probe: prevents grub-install from probing the host's
++      # /boot filesystem (e.g. /dev/md127 RAID) through the chroot mount,
++      # which causes 'unknown filesystem'. Safe because the PReP partition
++      # (GPT type 4100) needs no filesystem — GRUB writes its core image
++      # directly to raw partition space.
++      # --no-nvram: ofpathname (powerpc-utils) refuses to run on PowerNV
++      # bare-metal hosts ("not supported on the PowerNV Host platform"),
++      # so NVRAM update must be skipped. Harmless for image builds.
++      grub-install --target=powerpc-ieee1275 --skip-fs-probe --no-nvram "${LOOP_DEV}p1"
++    fi
++    grub-mkconfig -o /boot/grub/grub.cfg
++    sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" /boot/grub/grub.cfg
++  architectures:
++  - ppc64el
++  types:
++  - vm
++
++- trigger: post-files
++  action: |-
++    #!/bin/sh
++    set -eux
++
++    # Install zipl bootloader for s390x
++    LOOP_DEV="${DISTROBUILDER_LOOP_DEVICE}"
++    KERNEL=$(ls /boot/vmlinuz-* | head -n1)
++    INITRD=$(ls /boot/initrd.img-* | head -n1)
++
++    # Create zipl configuration
++    cat > /etc/zipl.conf << EOF
++    [defaultboot]
++    default = Ubuntu
++    target = /boot
++    targetbase = ${LOOP_DEV}
++    targettype = scsi
++    targetblocksize = 512
++    targetoffset = 2048
++
++    [Ubuntu]
++    image = ${KERNEL}
++    ramdisk = ${INITRD}
++    parameters = "root=${DISTROBUILDER_ROOT_UUID} ro console=ttysclp0"
++    EOF
++
++    # Install zipl
++    zipl -V -c /etc/zipl.conf
++  architectures:
++  - s390x
+   types:
+   - vm
+

--- a/patches/lxc-ci.patch
+++ b/patches/lxc-ci.patch
@@ -1,8 +1,6 @@
-diff --git a/images/ubuntu.yaml b/images/ubuntu.yaml
-index 81be31e..1429e76 100644
 --- a/images/ubuntu.yaml
 +++ b/images/ubuntu.yaml
-@@ -352,7 +352,9 @@ files:
+@@ -352,7 +352,9 @@
      network:
        version: 2
        ethernets:
@@ -13,11 +11,10 @@ index 81be31e..1429e76 100644
            dhcp4: true
            dhcp-identifier: mac
    types:
-@@ -498,6 +500,22 @@ packages:
-     types:
+@@ -504,6 +506,22 @@
      - vm
  
-+  - packages:
+   - packages:
 +    - grub-ieee1275
 +    action: install
 +    architectures:
@@ -33,13 +30,14 @@ index 81be31e..1429e76 100644
 +    types:
 +    - vm
 +
-   - packages:
-     - shim-signed
++  - packages:
+     - linux-image-virtual
      action: install
-@@ -648,5 +666,72 @@ actions:
+     types:
+@@ -644,6 +662,73 @@
  
-    update-grub
-    sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" /boot/grub/grub.cfg
+     update-grub
+     sed -i "s#root=[^ ]*#root=${DISTROBUILDER_ROOT_UUID}#g" /boot/grub/grub.cfg
 +  architectures:
 +  - amd64
 +  - arm64
@@ -109,4 +107,4 @@ index 81be31e..1429e76 100644
 +  - s390x
    types:
    - vm
-
+ 

--- a/scripts/helpers/build-distrobuilder-image.sh
+++ b/scripts/helpers/build-distrobuilder-image.sh
@@ -570,6 +570,8 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
         fi
     done
     
-    build_distrobuilder_ubuntu_image "${ARGS[@]}" "$BUILD_VM"
+    # Pass positional args (version, arch, workdir) separately from the BUILD_VM
+    # flag so that omitting workdir does not land "false" into $3/WORKDIR.
+    build_distrobuilder_ubuntu_image "${ARGS[0]}" "${ARGS[1]:-}" "${ARGS[2]:-}" "$BUILD_VM"
 fi
 

--- a/scripts/helpers/build-distrobuilder-image.sh
+++ b/scripts/helpers/build-distrobuilder-image.sh
@@ -10,6 +10,12 @@
 # Note: Do NOT use 'set -e' in sourced scripts as it affects the parent shell
 # Instead, use explicit error checking with || return 1
 
+# Script/repository location
+# Use BASH_SOURCE[0] instead of $0 to work correctly when sourced
+SCRIPT_PATH="$(realpath "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
+REPO_ROOT="$(realpath "$SCRIPT_DIR/../..")"
+
 # Color codes for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -92,6 +98,7 @@ install_dependencies() {
                 qemu-utils \
                 gdisk \
                 dosfstools \
+                btrfs-progs \
                 git \
                 wget \
                 xz-utils >/dev/null 2>&1
@@ -111,9 +118,29 @@ install_dependencies() {
                 qemu-img \
                 gdisk \
                 dosfstools \
+                btrfs-progs \
                 git \
                 wget \
-                xz >/dev/null 2>&1
+                xz \
+                patch >/dev/null 2>&1
+            ;;
+        fedora)
+            log_info "Installing dependencies via dnf (Fedora)..."
+            dnf clean all -q
+            dnf install -y -q \
+                golang \
+                debootstrap \
+                rsync \
+                squashfs-tools \
+                make \
+                qemu-img \
+                gdisk \
+                dosfstools \
+                btrfs-progs \
+                git \
+                wget \
+                xz \
+                patch >/dev/null 2>&1
             ;;
         *)
             log_error "Unsupported OS: ${os_type}"
@@ -124,25 +151,48 @@ install_dependencies() {
     log_success "Dependencies installed"
 }
 
-# Function to build and install distrobuilder
+# Function to build and install distrobuilder with IBM platform VM patches.
+# Rebuilds automatically whenever patches/distrobuilder.patch changes (stamp-file check).
 install_distrobuilder() {
     log_info "Checking distrobuilder installation..."
-    
-    # Check if distrobuilder is already installed
-    if command -v distrobuilder &>/dev/null; then
+
+    local patch_file="${REPO_ROOT}/patches/distrobuilder.patch"
+    local stamp_file="/usr/local/bin/distrobuilder.patch.sha256"
+
+    # Compute current patch checksum (empty string if patch file absent)
+    local current_sha=""
+    if [[ -f "$patch_file" ]]; then
+        current_sha=$(sha256sum "$patch_file" | awk '{print $1}')
+    fi
+
+    # Read the checksum that was in effect when the binary was last built
+    local installed_sha=""
+    if [[ -f "$stamp_file" ]]; then
+        installed_sha=$(cat "$stamp_file")
+    fi
+
+    # Skip rebuild only when the binary exists AND the patch hasn't changed
+    if command -v distrobuilder &>/dev/null && [[ "$current_sha" == "$installed_sha" ]]; then
         local version
         version=$(distrobuilder --version 2>&1 | head -n1 || echo "unknown")
-        log_info "distrobuilder already installed: ${version}"
+        log_info "distrobuilder already installed and up-to-date: ${version}"
         return 0
     fi
-    
-    log_info "Building distrobuilder from source..."
-    
+
+    if command -v distrobuilder &>/dev/null; then
+        log_info "Patch checksum changed — rebuilding distrobuilder with updated patches..."
+    else
+        log_info "Building distrobuilder from source with IBM platform VM patches..."
+    fi
+
+    log_info "Repo root: ${REPO_ROOT}"
+    log_info "Patch file: ${patch_file}"
+
     # Create temporary build directory
     local build_dir
     build_dir=$(mktemp -d)
     cd "$build_dir" || return 1
-    
+
     # Clone distrobuilder
     log_info "Cloning distrobuilder repository..."
     if ! git clone -q https://github.com/lxc/distrobuilder; then
@@ -150,9 +200,26 @@ install_distrobuilder() {
         rm -rf "$build_dir"
         return 1
     fi
-    
+
     cd distrobuilder || return 1
-    
+
+    # Apply IBM platform VM patches (covers ppc64le + s390x + fstab fixes)
+    if [[ -f "$patch_file" ]]; then
+        log_info "Applying IBM platform VM support patches..."
+        if ! patch -p1 < "$patch_file"; then
+            log_error "Failed to apply distrobuilder patches — patch did not apply cleanly."
+            log_error "The patch may be out of sync with the upstream distrobuilder source."
+            rm -rf "$build_dir"
+            return 1
+        fi
+        log_success "Patches applied successfully"
+    else
+        log_error "Patch file not found: $patch_file"
+        log_error "Cannot build a correctly patched distrobuilder without it."
+        rm -rf "$build_dir"
+        return 1
+    fi
+
     # Build distrobuilder
     log_info "Building distrobuilder (this may take a few minutes)..."
     if ! make >/dev/null 2>&1; then
@@ -160,25 +227,27 @@ install_distrobuilder() {
         rm -rf "$build_dir"
         return 1
     fi
-    
+
     # Install binary
     local gobin
     gobin="$(go env GOPATH)/bin"
-    
+
     if [[ -f "${gobin}/distrobuilder" ]]; then
         log_info "Installing distrobuilder to /usr/local/bin..."
         install -m 755 "${gobin}/distrobuilder" /usr/local/bin/
+        # Write stamp so we know which patch version this binary was built from
+        echo "$current_sha" > "$stamp_file"
         log_success "distrobuilder installed successfully"
     else
         log_error "distrobuilder binary not found after build"
         rm -rf "$build_dir"
         return 1
     fi
-    
+
     # Cleanup build directory
     cd /
     rm -rf "$build_dir"
-    
+
     # Verify installation
     if command -v distrobuilder &>/dev/null; then
         local version
@@ -195,10 +264,22 @@ build_distrobuilder_ubuntu_image() {
     local VERSION="$1"
     local ARCH="${2:-$(uname -m)}"
     local WORKDIR="${3:-$HOME/incus-images/official-ubuntu}"
+    local BUILD_VM="${4:-false}"  # New parameter for VM builds
     
     # Validate version
     if [[ ! "$VERSION" =~ ^(22.04|24.04)$ ]]; then
         log_error "Invalid Ubuntu version: $VERSION. Must be 22.04 or 24.04"
+        return 1
+    fi
+
+    # ppc64le VM builds: only Ubuntu 24.04 (noble) is supported.
+    # Ubuntu 22.04 (jammy) ships GRUB 2.06 which cannot complete installation
+    # inside the distrobuilder chroot environment; the resulting image is not
+    # bootable. 22.04 container images remain supported on all architectures.
+    if [[ "$BUILD_VM" == "true" && "$ARCH" == "ppc64le" && "$VERSION" == "22.04" ]]; then
+        log_error "Ubuntu 22.04 ppc64le VM images are not supported."
+        log_error "GRUB 2.06 (jammy) cannot install correctly in the distrobuilder"
+        log_error "chroot environment. Use Ubuntu 24.04 for ppc64le VM builds."
         return 1
     fi
     
@@ -206,27 +287,26 @@ build_distrobuilder_ubuntu_image() {
     local CODENAME
     CODENAME=$(get_release_codename "$VERSION")
     
-    # Define image alias
+    # Define image alias (add -vm suffix for VM images)
     local IMAGE_ALIAS="ubuntu-${VERSION}"
+    local IMAGE_TYPE="container"
+    if [[ "$BUILD_VM" == "true" ]]; then
+        IMAGE_ALIAS="${IMAGE_ALIAS}-vm"
+        IMAGE_TYPE="virtual-machine"
+    fi
     
     log_info "=========================================="
     log_info "Building Ubuntu ${VERSION} (${CODENAME})"
     log_info "Architecture: ${ARCH}"
+    log_info "Image Type: ${IMAGE_TYPE}"
     log_info "Image Alias: ${IMAGE_ALIAS}"
     log_info "Build Method: distrobuilder"
     log_info "=========================================="
     
     # Check if image already exists
     if check_image_exists "$IMAGE_ALIAS"; then
-        log_warn "Image '${IMAGE_ALIAS}' already exists in Incus"
-        read -p "Do you want to rebuild? (y/N): " -n 1 -r
-        echo
-        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-            log_info "Skipping build for ${IMAGE_ALIAS}"
-            return 0
-        fi
-        log_info "Removing existing image..."
-        incus image delete "$IMAGE_ALIAS" || true
+        log_info "Image '${IMAGE_ALIAS}' already exists in Incus. Skipping build."
+        return 0
     fi
     
     # Install dependencies
@@ -242,6 +322,16 @@ build_distrobuilder_ubuntu_image() {
         return 1
     fi
     
+    # Use global REPO_ROOT
+    local repo_root="$REPO_ROOT"
+    
+    # Log repo root detection result
+    if [[ -d "$repo_root/patches" ]]; then
+        log_info "Found repo root: $repo_root"
+    else
+        log_warn "Could not locate patches directory"
+    fi
+    
     # Create working directory
     log_info "Creating workspace: ${WORKDIR}"
     mkdir -p "$WORKDIR"
@@ -254,6 +344,10 @@ build_distrobuilder_ubuntu_image() {
     # Cleanup function
     cleanup_files() {
         log_info "Cleaning up build artifacts..."
+        if [[ -f "$WORKDIR/build.log" ]]; then
+            cp "$WORKDIR/build.log" /tmp/distrobuilder-build.log 2>/dev/null || true
+            log_info "build.log preserved at /tmp/distrobuilder-build.log"
+        fi
         if [[ -d "$WORKDIR" ]]; then
             rm -rf "${WORKDIR:?}"/*
         fi
@@ -272,39 +366,114 @@ build_distrobuilder_ubuntu_image() {
     fi
     log_success "Image definition downloaded"
     
+    # Apply IBM platform patches to ubuntu.yaml — required for s390x/ppc64le support
+    local yaml_patch="${REPO_ROOT}/patches/lxc-ci.patch"
+    log_info "Patch file path: $yaml_patch"
+
+    if [[ ! -f "$yaml_patch" ]]; then
+        log_error "Patch file not found: $yaml_patch"
+        log_error "Cannot build a correctly patched ubuntu.yaml without it."
+        cleanup_files
+        return 1
+    fi
+
+    log_info "Applying IBM platform patches to ubuntu.yaml..."
+    # Create images directory structure matching the patch's path prefix
+    mkdir -p images
+    mv ubuntu.yaml images/ubuntu.yaml
+    if ! patch -p1 < "$yaml_patch"; then
+        log_error "Failed to apply lxc-ci patches — patch did not apply cleanly."
+        log_error "The patch may be out of sync with the upstream ubuntu.yaml."
+        mv images/ubuntu.yaml ubuntu.yaml 2>/dev/null || true
+        rmdir images 2>/dev/null || true
+        cleanup_files
+        return 1
+    fi
+    log_success "ubuntu.yaml patches applied successfully"
+    mv images/ubuntu.yaml ubuntu.yaml
+    rmdir images 2>/dev/null || true
+    
     # Build image with distrobuilder
-    log_info "Building Ubuntu ${VERSION} image (this will take several minutes)..."
+    log_info "Building Ubuntu ${VERSION} ${IMAGE_TYPE} image (this will take several minutes)..."
     log_info "Architecture: ${ARCH}, Release: ${CODENAME}"
     
-    if ! distrobuilder build-incus ubuntu.yaml \
+    # Add --vm flag for VM builds
+    local VM_FLAG=""
+    if [[ "$BUILD_VM" == "true" ]]; then
+        VM_FLAG="--vm"
+        log_info "Building as virtual machine image"
+    fi
+    
+    # Mirror selection: try the FAU mirror first (faster, reliable),
+    # fall back to the official Ubuntu ports mirror if it fails.
+    local PRIMARY_MIRROR="https://ftp.fau.de/ubuntu-ports"
+    local FALLBACK_MIRROR="https://ports.ubuntu.com/ubuntu-ports"
+    local SOURCE_URL="$PRIMARY_MIRROR"
+
+    log_info "Checking primary mirror: ${PRIMARY_MIRROR}..."
+    if wget -q --spider --timeout=10 "${PRIMARY_MIRROR}/dists/${CODENAME}/Release" 2>/dev/null; then
+        log_info "Primary mirror reachable — using ${PRIMARY_MIRROR}"
+    else
+        log_warn "Primary mirror unreachable — falling back to ${FALLBACK_MIRROR}"
+        SOURCE_URL="$FALLBACK_MIRROR"
+    fi
+    log_info "Selected mirror: ${SOURCE_URL}"
+
+    # Run distrobuilder. Use PIPESTATUS[0] because the pipeline
+    # (| tee build.log) would otherwise mask a non-zero exit code.
+    local distro_rc=0
+    distrobuilder build-incus ubuntu.yaml ${VM_FLAG} \
         -o image.architecture="${ARCH}" \
         -o image.release="${CODENAME}" \
         -o image.variant=default \
-        -o source.url=http://ports.ubuntu.com/ubuntu-ports 2>&1 | tee build.log; then
-        log_error "Failed to build image with distrobuilder"
+        -o source.url="${SOURCE_URL}" 2>&1 | tee build.log
+    distro_rc=${PIPESTATUS[0]}
+
+    if [[ "$distro_rc" -ne 0 ]]; then
+        log_error "distrobuilder exited with status ${distro_rc}"
+        log_error "Mirror used: ${SOURCE_URL}"
         log_error "Check build.log for details"
         cleanup_files
         return 1
     fi
-    
+
     log_success "Image build completed"
     
-    # Check for generated artifacts
-    if [[ ! -f "incus.tar.xz" ]] || [[ ! -f "rootfs.squashfs" ]]; then
-        log_error "Build artifacts not found (incus.tar.xz or rootfs.squashfs)"
-        cleanup_files
-        return 1
-    fi
-    
-    log_info "Build artifacts:"
-    ls -lh incus.tar.xz rootfs.squashfs
-    
-    # Import into Incus
-    log_info "Importing image into Incus with alias '${IMAGE_ALIAS}'..."
-    if ! incus image import incus.tar.xz rootfs.squashfs --alias "$IMAGE_ALIAS"; then
-        log_error "Failed to import image into Incus"
-        cleanup_files
-        return 1
+    # Check for generated artifacts (different for VMs vs containers)
+    if [[ "$BUILD_VM" == "true" ]]; then
+        # VM builds produce disk image
+        if [[ ! -f "incus.tar.xz" ]] || [[ ! -f "disk.qcow2" ]]; then
+            log_error "VM build artifacts not found (incus.tar.xz or disk.qcow2)"
+            cleanup_files
+            return 1
+        fi
+        log_info "VM Build artifacts:"
+        ls -lh incus.tar.xz disk.qcow2
+        
+        # Import VM into Incus
+        log_info "Importing VM image into Incus with alias '${IMAGE_ALIAS}'..."
+        if ! incus image import incus.tar.xz disk.qcow2 --alias "$IMAGE_ALIAS"; then
+            log_error "Failed to import VM image into Incus"
+            cleanup_files
+            return 1
+        fi
+    else
+        # Container builds produce rootfs
+        if [[ ! -f "incus.tar.xz" ]] || [[ ! -f "rootfs.squashfs" ]]; then
+            log_error "Container build artifacts not found (incus.tar.xz or rootfs.squashfs)"
+            cleanup_files
+            return 1
+        fi
+        log_info "Container Build artifacts:"
+        ls -lh incus.tar.xz rootfs.squashfs
+        
+        # Import container into Incus
+        log_info "Importing container image into Incus with alias '${IMAGE_ALIAS}'..."
+        if ! incus image import incus.tar.xz rootfs.squashfs --alias "$IMAGE_ALIAS"; then
+            log_error "Failed to import container image into Incus"
+            cleanup_files
+            return 1
+        fi
     fi
     log_success "Image imported successfully"
     
@@ -360,12 +529,31 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     
     # Parse arguments
     if [[ $# -lt 1 ]]; then
-        echo "Usage: $0 <version> [arch] [workdir]"
+        echo "Usage: $0 <version> [arch] [workdir] [--vm]"
         echo "  version: 22.04 or 24.04"
         echo "  arch: ppc64le, s390x, or x86_64 (default: auto-detect)"
         echo "  workdir: Build directory (default: ~/incus-images/official-ubuntu)"
+        echo "  --vm: Build VM image instead of container (optional)"
         return 1
     fi
     
-    build_distrobuilder_ubuntu_image "$@"
+    # Check for --vm flag
+    BUILD_VM="false"
+    for arg in "$@"; do
+        if [[ "$arg" == "--vm" ]]; then
+            BUILD_VM="true"
+            break
+        fi
+    done
+    
+    # Remove --vm from arguments if present
+    ARGS=()
+    for arg in "$@"; do
+        if [[ "$arg" != "--vm" ]]; then
+            ARGS+=("$arg")
+        fi
+    done
+    
+    build_distrobuilder_ubuntu_image "${ARGS[@]}" "$BUILD_VM"
 fi
+

--- a/scripts/helpers/build-distrobuilder-image.sh
+++ b/scripts/helpers/build-distrobuilder-image.sh
@@ -381,17 +381,33 @@ build_distrobuilder_ubuntu_image() {
     # Create images directory structure matching the patch's path prefix
     mkdir -p images
     mv ubuntu.yaml images/ubuntu.yaml
-    if ! patch -p1 < "$yaml_patch"; then
+    # 'git apply' is used instead of 'patch' because GNU patch misinterprets
+    # shell variable syntax (${VAR}) in patch hunks as malformed directives.
+    # git apply requires a git repository, so we initialise a throwaway one in
+    # WORKDIR if we are not already inside one (e.g. on CentOS build hosts where
+    # the workspace directory is outside any repo).
+    local _git_init_needed=false
+    if ! git -C "$WORKDIR" rev-parse --git-dir &>/dev/null; then
+        git -C "$WORKDIR" init -q
+        _git_init_needed=true
+    fi
+    if ! git -C "$WORKDIR" apply --whitespace=nowarn "$yaml_patch"; then
         log_error "Failed to apply lxc-ci patches — patch did not apply cleanly."
         log_error "The patch may be out of sync with the upstream ubuntu.yaml."
         mv images/ubuntu.yaml ubuntu.yaml 2>/dev/null || true
         rmdir images 2>/dev/null || true
+        if [[ "$_git_init_needed" == "true" ]]; then
+            rm -rf "$WORKDIR/.git"
+        fi
         cleanup_files
         return 1
     fi
     log_success "ubuntu.yaml patches applied successfully"
     mv images/ubuntu.yaml ubuntu.yaml
     rmdir images 2>/dev/null || true
+    if [[ "$_git_init_needed" == "true" ]]; then
+        rm -rf "$WORKDIR/.git"
+    fi
     
     # Build image with distrobuilder
     log_info "Building Ubuntu ${VERSION} ${IMAGE_TYPE} image (this will take several minutes)..."


### PR DESCRIPTION
## Summary

Adds the distrobuilder build helper for ppc64le and s390x VM base image builds, and the IBM platform patches that distrobuilder applies to ubuntu.yaml. x86_64 and aarch64 pull pre-built VM images from the Incus image server; ppc64le and s390x must build from source.


## Changes

### `scripts/helpers/build-distrobuilder-image.sh`
Orchestrates Ubuntu VM base image builds via distrobuilder:
- Architecture-aware: skips distrobuilder for arches that have pre-built images on the Incus image server
- Mirror selection: FAU mirror as primary, Ubuntu ports as fallback checked via wget --spider before use)
- Artifact validation: verifies incus.tar.xz and disk.qcow2 exist before importing into Incus
- Early exit with clear error for unsupported combinations (Ubuntu 22.04 ppc64le VM — GRUB 2.06 incompatible with
  distrobuilder mount options)
- Stamp file to skip rebuild when patches have not changed

### `patches/distrobuilder.patch`
Extends distrobuilder with IBM platform support:
- ppc64le: PReP partition layout (8 MiB, GPT type 4100)
- s390x: ext4 boot partition layout (500 MiB)
- Exposes `DISTROBUILDER_LOOP_DEVICE` env var so post-files bootloader actions can target the correct loop device
- Adds zipl bootloader support for s390x

### `patches/lxc-ci.patch`
Modifies ubuntu.yaml for IBM platform VM builds:
- Netplan wildcard interface match (`id0` / `en*`) to handle varying NIC names across architectures
- Install `grub-ieee1275` on ppc64le and `s390-tools` on s390x
- ppc64le post-files GRUB action:
  - `--no-nvram`: ofpathname refuses to run on PowerNV bare-metal
  - `--skip-fs-probe`: prevents host RAID /boot probe through the chroot mount causing "unknown filesystem"
  - Targets PReP partition (`${LOOP_DEV}p1`) directly
  - Ubuntu 22.04 ppc64le VM not supported (GRUB 2.06 limitation)
- s390x post-files zipl action with loop device and UUID substitution

## Test evidence
- `ubuntu-24.04-vm` builds and imports successfully on ppc64le